### PR TITLE
fix: update Dockerfile base images to .NET 10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-# Use the official .NET 8 runtime as base image
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+# Use the official .NET 10 runtime as base image
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
 WORKDIR /app
 EXPOSE 8080
 
 # Use the SDK image to build the app
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
 # Copy only production project files (exclude test projects)


### PR DESCRIPTION
## Summary

- Bumps `mcr.microsoft.com/dotnet/aspnet:8.0` → `aspnet:10.0`
- Bumps `mcr.microsoft.com/dotnet/sdk:8.0` → `sdk:10.0`

## Root cause

Commit 978d3f6 updated all three project files to `net10.0` but the Dockerfile was not updated alongside it. The .NET 8 SDK rejects a `net10.0` target with `NETSDK1045`, causing the Docker CI build to fail immediately at `dotnet restore`.

## Test plan

- [ ] Docker CI workflow passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)