### PR TITLE
fix: move deploy script to home dir to avoid self-deletion on wipe

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -44,4 +44,4 @@ jobs:
 
     steps:
       - name: Deploy
-        run: /opt/questboard/deploy.sh ${{ github.event.inputs.tag || github.ref_name }}
+        run: /home/questboard/deploy.sh ${{ github.event.inputs.tag || github.ref_name }}

--- a/docs/server-setup.md
+++ b/docs/server-setup.md
@@ -71,7 +71,7 @@ chown questboard:questboard /etc/questboard/env
 ### Create the deploy script
 
 ```bash
-cat > /opt/questboard/deploy.sh <<'EOF'
+cat > /home/questboard/deploy.sh <<'EOF'
 #!/bin/bash
 set -e
 
@@ -89,18 +89,13 @@ wget -q -O /tmp/questboard.zip "https://github.com/$REPO/releases/download/$TAG/
 sudo systemctl stop questboard
 rm -rf /opt/questboard/*
 unzip -q /tmp/questboard.zip -d /opt/questboard/
-
-# Restore the deploy script (unzip overwrote it)
-cp "$0" /opt/questboard/deploy.sh
-chmod +x /opt/questboard/deploy.sh
-
 rm /tmp/questboard.zip
 sudo systemctl start questboard
 echo "Done: $TAG deployed."
 EOF
 
-chmod +x /opt/questboard/deploy.sh
-chown questboard:questboard /opt/questboard/deploy.sh
+chmod +x /home/questboard/deploy.sh
+chown questboard:questboard /home/questboard/deploy.sh
 ```
 
 ### Allow questboard to restart the service


### PR DESCRIPTION
## Summary

- Moves `deploy.sh` from `/opt/questboard/` to `/home/questboard/` so it is never in the path that gets wiped on every deploy
- Removes the now-unnecessary self-preservation `cp` lines from the script
- Updates the workflow to call `/home/questboard/deploy.sh`
- Updates docs to match

## Root cause

The deploy script lived in `/opt/questboard/` which is wiped with `rm -rf /opt/questboard/*` on every deploy. The self-preservation step (`cp "$0" ...`) failed because `$0` itself had already been deleted by that point.