### PR TITLE
fix: remove -r linux-x64 from publish to avoid IIS assembly mismatch

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -26,7 +26,7 @@ jobs:
           dotnet-version: '10.0.x'
 
       - name: Publish
-        run: dotnet publish EuphoriaInn.Service/EuphoriaInn.Service.csproj -c Release -r linux-x64 --self-contained false -o ./publish
+        run: dotnet publish EuphoriaInn.Service/EuphoriaInn.Service.csproj -c Release -o ./publish
 
       - name: Zip artifact
         run: cd publish && zip -r ../questboard-${{ github.ref_name }}.zip .


### PR DESCRIPTION
## Summary

Removes `-r linux-x64 --self-contained false` from the `dotnet publish` command, replacing it with a plain framework-dependent publish — matching exactly what the Dockerfile does.

## Root cause

Specifying `-r linux-x64` causes platform-specific assemblies (including `Microsoft.AspNetCore.Server.IIS`) to be included in the publish output. When the app starts on Linux, the runtime cannot load `IISServerOptions` from that assembly, causing a `TypeLoadException` on startup.

The Dockerfile does not specify a RID, which avoids this issue entirely.