### PR TITLE
fix: remove IISServerOptions config — causes TypeLoadException on Linux

### DIFF
--- a/EuphoriaInn.Service/Program.cs
+++ b/EuphoriaInn.Service/Program.cs
@@ -17,11 +17,6 @@ builder.Services.Configure<KestrelServerOptions>(options =>
     options.Limits.MaxRequestBodySize = 10 * 1024 * 1024; // 10 MB (slightly higher than validation to allow for form overhead)
 });
 
-// Configure IIS server limits (if running on IIS)
-builder.Services.Configure<IISServerOptions>(options =>
-{
-    options.MaxRequestBodySize = 10 * 1024 * 1024; // 10 MB
-});
 
 // Add services to the container.
 builder.Services.AddControllersWithViews();


### PR DESCRIPTION
## Summary

Removes the `Configure<IISServerOptions>` block from `Program.cs`.

## Root cause

`IISServerOptions` is a Windows-only type. On Linux, the runtime cannot load it from the `Microsoft.AspNetCore.Server.IIS` assembly, causing a `TypeLoadException` on startup and the app crash-looping.

The Kestrel limit on the lines above already enforces the same 10MB request body restriction, so nothing is lost.