### PR TITLE
feat: send confirmation email on self-registration

### DIFF
--- a/EuphoriaInn.Domain/Interfaces/IIdentityService.cs
+++ b/EuphoriaInn.Domain/Interfaces/IIdentityService.cs
@@ -23,5 +23,6 @@ public interface IIdentityService
     Task<IdentityResult> AdminResetPasswordAsync(ClaimsPrincipal adminUser, int targetUserId, string newPassword);
     Task<string?> GenerateEmailConfirmationAsync(int userId);
     Task<IdentityResult> ConfirmEmailAsync(int userId, string token);
+    Task<int?> GetIdByEmailAsync(string email);
     Task SignOutAsync();
 }

--- a/EuphoriaInn.Repository/IdentityService.cs
+++ b/EuphoriaInn.Repository/IdentityService.cs
@@ -109,6 +109,12 @@ internal class IdentityService(UserManager<UserEntity> userManager, SignInManage
         return await userManager.ResetPasswordAsync(entity, resetToken, newPassword);
     }
 
+    public async Task<int?> GetIdByEmailAsync(string email)
+    {
+        var entity = await userManager.FindByEmailAsync(email);
+        return entity?.Id;
+    }
+
     public async Task<string?> GenerateEmailConfirmationAsync(int userId)
     {
         var entity = await userManager.FindByIdAsync(userId.ToString());

--- a/EuphoriaInn.Service/Controllers/Admin/AccountController.cs
+++ b/EuphoriaInn.Service/Controllers/Admin/AccountController.cs
@@ -1,6 +1,8 @@
 using EuphoriaInn.Domain.Interfaces;
 using EuphoriaInn.Service.Controllers.QuestBoard;
+using EuphoriaInn.Service.Jobs;
 using EuphoriaInn.Service.ViewModels.AccountViewModels;
+using Hangfire;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.WebUtilities;
@@ -9,7 +11,7 @@ using System.Text;
 
 namespace EuphoriaInn.Service.Controllers.Admin;
 
-public class AccountController(IUserService userService, IIdentityService identityService, ILogger<AccountController> logger) : Controller
+public class AccountController(IUserService userService, IIdentityService identityService, IBackgroundJobClient jobClient, ILogger<AccountController> logger) : Controller
 {
     [HttpGet]
     public IActionResult Login(string? returnUrl = null)
@@ -96,6 +98,17 @@ public class AccountController(IUserService userService, IIdentityService identi
 
             if (result.Succeeded)
             {
+                var userId = await identityService.GetIdByEmailAsync(model.Email);
+                if (userId.HasValue)
+                {
+                    var rawToken = await identityService.GenerateEmailConfirmationAsync(userId.Value);
+                    if (rawToken != null)
+                    {
+                        var encodedToken = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(rawToken));
+                        var callbackUrl = Url.Action("ConfirmEmail", "Account", new { userId = userId.Value, token = encodedToken }, Request.Scheme);
+                        jobClient.Enqueue<ConfirmationEmailJob>(j => j.ExecuteAsync(model.Email, model.Name, callbackUrl!, CancellationToken.None));
+                    }
+                }
                 return RedirectToLocal(returnUrl);
             }
 


### PR DESCRIPTION
## Summary

- Confirmation email is now automatically queued when a user registers a new account
- Uses the existing `ConfirmationEmailJob` Hangfire path — same email template and delivery mechanism as the admin-triggered resend
- Token generation failure is silent (registration still succeeds, admin can still resend manually)

## What Changed

**`IIdentityService` + `IdentityService`** — Added `GetIdByEmailAsync(string email)` to resolve a newly created user's ID by email. Implemented via the existing `userManager.FindByEmailAsync`, consistent with other methods in the class.

**`AccountController.Register`** — After a successful `CreateAsync`, the action now:
1. Looks up the new user's ID via `GetIdByEmailAsync`
2. Generates an email confirmation token via `GenerateEmailConfirmationAsync`
3. Builds the callback URL (same pattern as `AdminController.SendConfirmationEmail`)
4. Enqueues `ConfirmationEmailJob` via `IBackgroundJobClient`

`IBackgroundJobClient` added to `AccountController`'s primary constructor — `NoOpBackgroundJobClient` is already registered in `WebApplicationFactoryBase` so no test factory changes are needed.

## Reviewer Notes

- The admin "Send Confirmation Email" button still works independently as a resend path
- Both paths enqueue the same `ConfirmationEmailJob` — no duplicate template or logic
- If token generation returns `null` (e.g. user lookup race), registration still completes and the admin can resend manually
- 191 tests pass (52 unit + 139 integration)
- This branch was cut from `milestone/4-email` and depends on the Hangfire infrastructure landed there

## Test Plan

- [ ] Register a new account — confirmation email arrives in inbox
- [ ] Confirm via the link in the email — login succeeds
- [ ] Admin resend button on Users panel still works for accounts that didn't receive the email
- [ ] `dotnet test` — 191/191 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)