### PR TITLE
Fix mobile GroupPicker white-page bug (unrendered Styles section)

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -42,6 +42,12 @@ Items acknowledged and deferred at milestone close on 2026-07-02:
 | tech debt | `GroupSessionMiddleware` redirects on POST — data-loss risk if session expires mid-submission | Deferred — flagged by code review in Phase 31, not yet fixed |
 | requirement | Profile picture crop/avatar selection (issue #78) | Deferred since v2.x — SkiaSharp native lib availability unverified on deployment host |
 
+## Quick Tasks Completed
+
+| # | Description | Date | Commit | Directory |
+|---|-------------|------|--------|-----------|
+| 260702-t9m | Fix mobile GroupPicker index white-page bug caused by unrendered Styles section in _Layout.GroupPicker.cshtml | 2026-07-02 | 82aa549 | [260702-t9m-fix-mobile-grouppicker-index-white-page-](./quick/260702-t9m-fix-mobile-grouppicker-index-white-page-/) |
+
 ## Accumulated Context
 
 ### Pending for Next Milestone
@@ -61,3 +67,5 @@ Full per-phase architectural decisions, deviations, and performance metrics for 
 Last session: 2026-07-02T13:00:01.218Z
 Stopped at: v5.0 milestone archived
 Next step: `/gsd:new-milestone`
+
+Last activity: 2026-07-02 - Completed quick task 260702-t9m: Fix mobile GroupPicker index white-page bug caused by unrendered Styles section in _Layout.GroupPicker.cshtml

--- a/.planning/quick/260702-t9m-fix-mobile-grouppicker-index-white-page-/260702-t9m-PLAN.md
+++ b/.planning/quick/260702-t9m-fix-mobile-grouppicker-index-white-page-/260702-t9m-PLAN.md
@@ -1,0 +1,160 @@
+---
+phase: quick-260702-t9m
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - QuestBoard.Service/Views/Shared/_Layout.GroupPicker.cshtml
+  - QuestBoard.IntegrationTests/Mobile/MobileViewsTests.cs
+autonomous: true
+requirements: []
+must_haves:
+  truths:
+    - "An authenticated mobile user visiting /GroupPicker/Index sees the group-selection cards, not a blank white page"
+    - "The account.mobile.css stylesheet declared by Index.Mobile.cshtml's Styles section is rendered into the <head>"
+    - "The desktop /GroupPicker/Index view still renders unchanged (it defines no Styles section)"
+  artifacts:
+    - path: "QuestBoard.Service/Views/Shared/_Layout.GroupPicker.cshtml"
+      provides: "RenderSectionAsync(\"Styles\", required: false) in <head> so views using this layout may inject page-specific stylesheets"
+      contains: "RenderSectionAsync(\"Styles\""
+    - path: "QuestBoard.IntegrationTests/Mobile/MobileViewsTests.cs"
+      provides: "Regression test asserting /GroupPicker/Index returns 200 with mobile group-selection markup under a mobile UA"
+      contains: "GroupPicker"
+  key_links:
+    - from: "QuestBoard.Service/Views/GroupPicker/Index.Mobile.cshtml"
+      to: "QuestBoard.Service/Views/Shared/_Layout.GroupPicker.cshtml"
+      via: "@section Styles rendered by @await RenderSectionAsync(\"Styles\", required: false)"
+      pattern: "RenderSectionAsync\\(\"Styles\""
+---
+
+<objective>
+Fix the blank white page shown to mobile users on GroupPicker's Index view.
+
+The mobile view `Index.Mobile.cshtml` declares `@section Styles { ... }` (to link `account.mobile.css`), but its layout `_Layout.GroupPicker.cshtml` never renders a `Styles` section. Razor throws `InvalidOperationException` ("The following sections have been defined but have not been rendered ... 'Styles'") when a defined section is not rendered, which surfaces as a blank/white page. The desktop `Index.cshtml` uses the same layout but defines no `Styles` section, so it is unaffected.
+
+Purpose: Restore GroupPicker for mobile users — a broken group switch blocks the core "DMs post quests, players sign up" loop for anyone on a phone.
+Output: One-line fix to the layout plus a regression test that drives the mobile path so this cannot silently regress.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/STATE.md
+
+<interfaces>
+<!-- The layout that is missing the section render. Note it already renders Scripts. -->
+From QuestBoard.Service/Views/Shared/_Layout.GroupPicker.cshtml (head, current):
+```html
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@ViewData["Title"] - D&D Quest Board</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
+</head>
+```
+Later in the same file (already present — Scripts is fine, do not touch):
+```html
+@await RenderSectionAsync("Scripts", required: false)
+```
+
+<!-- The mobile view that defines the section — this is what currently crashes. Do NOT edit it. -->
+From QuestBoard.Service/Views/GroupPicker/Index.Mobile.cshtml:
+```cshtml
+Layout = "~/Views/Shared/_Layout.GroupPicker.cshtml";
+@section Styles {
+    <link href="~/css/account.mobile.css" asp-append-version="true" rel="stylesheet" />
+}
+... renders <div class="account-card-mobile mb-3"> ... "Select Your Group" cards ...
+```
+
+<!-- The established convention to match — sibling layout renders Styles in <head>, required:false. -->
+From QuestBoard.Service/Views/Shared/_Layout.Mobile.cshtml (head):
+```html
+    <link rel="stylesheet" href="~/css/mobile.css" asp-append-version="true" />
+    @await RenderSectionAsync("Styles", required: false)
+</head>
+```
+
+<!-- Route + auth facts for the regression test. -->
+GroupPickerController: [Authorize], Index is [HttpGet] at /GroupPicker/Index (and /groups/pick).
+Mobile view resolution: MobileViewLocationExpander swaps *.cshtml -> *.Mobile.cshtml when HttpContext.Items["IsMobile"] is true (set from the mobile User-Agent). So a mobile UA request to /GroupPicker/Index renders Index.Mobile.cshtml, which is the file that triggers the bug.
+
+<!-- Test harness convention (from existing tests in the same file). -->
+Authenticated mobile-view test pattern (MobileViewsTests.cs):
+  var (authClient, _) = await AuthenticationHelper.CreateAuthenticatedClientWithUserAsync(_factory, "<login>", "<email>");
+  var request = new HttpRequestMessage(HttpMethod.Get, "<url>");
+  request.Headers.TryAddWithoutValidation("User-Agent", MobileUserAgent);
+  request.Headers.Authorization = authClient.DefaultRequestHeaders.Authorization;
+  var response = await _client.SendAsync(request, TestContext.Current.CancellationToken);
+  var html = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+MobileUserAgent and _client/_factory fields already exist as private members of MobileViewsTests.
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Render the Styles section in the GroupPicker layout head</name>
+  <files>QuestBoard.Service/Views/Shared/_Layout.GroupPicker.cshtml</files>
+  <action>
+In `_Layout.GroupPicker.cshtml`, add a single line inside the `<head>` element, immediately after the last stylesheet link (`<link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />`) and before the closing `</head>`:
+
+`@await RenderSectionAsync("Styles", required: false)`
+
+Match the exact convention used in the sibling `_Layout.Mobile.cshtml`: use `@await RenderSectionAsync("Styles", required: false)` — the `required: false` argument is mandatory so that the desktop `Index.cshtml` (which defines no Styles section) keeps working. Do NOT touch the existing `@await RenderSectionAsync("Scripts", required: false)` line near `</body>` — it is already correct. Do NOT edit `Index.Mobile.cshtml` or `Index.cshtml`; the section definition there is correct and only the layout was missing the render call.
+
+This is the only structural gap in this layout chain: `Scripts` is already rendered, and no other required sections are defined by any view using this layout.
+  </action>
+  <verify>
+    <automated>grep -c 'RenderSectionAsync("Styles"' QuestBoard.Service/Views/Shared/_Layout.GroupPicker.cshtml</automated>
+  </verify>
+  <done>_Layout.GroupPicker.cshtml contains exactly one `@await RenderSectionAsync("Styles", required: false)` call inside the `<head>`, and still contains the pre-existing `RenderSectionAsync("Scripts", required: false)` call. No other files changed.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Add a mobile GroupPicker regression test</name>
+  <files>QuestBoard.IntegrationTests/Mobile/MobileViewsTests.cs</files>
+  <action>
+Add one `[Fact]` async test method to the existing `MobileViewsTests` class (reuse its existing `_client`, `_factory`, and `MobileUserAgent` members — do not add new fields or constructors).
+
+The test must:
+1. Create an authenticated client via `AuthenticationHelper.CreateAuthenticatedClientWithUserAsync(_factory, "gp_mobile01", "gp_mobile01@test.com")` (a plain authenticated player is sufficient — GroupPickerController only requires `[Authorize]`).
+2. Build an `HttpRequestMessage` GET to `/GroupPicker/Index`, set the `User-Agent` header to `MobileUserAgent` via `TryAddWithoutValidation`, and set `request.Headers.Authorization` to the authenticated client's `DefaultRequestHeaders.Authorization`.
+3. Send it through `_client.SendAsync(request, TestContext.Current.CancellationToken)` and read the HTML body.
+4. Assert `response.StatusCode.Should().Be(HttpStatusCode.OK)` — this is the primary regression guard: before the fix the unrendered `Styles` section throws and produces a 500 / blank page, so a 200 proves the section now renders.
+5. Assert `html.Should().Contain("account-card-mobile")` — proves the mobile view body rendered (this class comes from `Index.Mobile.cshtml`).
+6. Assert `html.Should().Contain("account.mobile.css")` — proves the `Styles` section content itself was emitted into the page.
+
+Follow the exact request-construction and assertion style of the existing authenticated mobile tests in this file (e.g. `MobileAccountEdit_MobileUserAgent_RendersGlassCardForm`). Name the test descriptively, e.g. `MobileGroupPicker_MobileUserAgent_RendersGroupCardsAndStylesSection`, with an XML doc comment explaining it guards against the unrendered-Styles-section white-page regression.
+  </action>
+  <verify>
+    <automated>dotnet test QuestBoard.IntegrationTests --filter "FullyQualifiedName~MobileGroupPicker_MobileUserAgent_RendersGroupCardsAndStylesSection"</automated>
+  </verify>
+  <done>The new test compiles and passes: a mobile-UA authenticated GET to /GroupPicker/Index returns 200 and the HTML contains both `account-card-mobile` and `account.mobile.css`. (Reverting Task 1 would make this test fail — confirming it guards the regression.)</done>
+</task>
+
+</tasks>
+
+<verification>
+- `dotnet build` succeeds (Razor layout change is valid).
+- Full mobile suite still green: `dotnet test QuestBoard.IntegrationTests --filter "FullyQualifiedName~Mobile"` — confirms the desktop GroupPicker parity and other layouts are unaffected.
+- Manual (optional): with a mobile User-Agent, navigate to /GroupPicker/Index while logged in — the "Select Your Group" cards render instead of a white page.
+</verification>
+
+<success_criteria>
+- Mobile users reach the GroupPicker group-selection page (no white page / no unrendered-section exception).
+- `account.mobile.css` is present in the rendered `<head>`.
+- Desktop GroupPicker Index and all other views using `_Layout.GroupPicker.cshtml` are unchanged in behavior.
+- A regression test locks in the mobile GroupPicker path so this cannot silently break again.
+</success_criteria>
+
+<output>
+Create `.planning/quick/260702-t9m-fix-mobile-grouppicker-index-white-page-/260702-t9m-SUMMARY.md` when done.
+</output>

--- a/.planning/quick/260702-t9m-fix-mobile-grouppicker-index-white-page-/260702-t9m-SUMMARY.md
+++ b/.planning/quick/260702-t9m-fix-mobile-grouppicker-index-white-page-/260702-t9m-SUMMARY.md
@@ -1,0 +1,38 @@
+---
+phase: quick-260702-t9m
+plan: 01
+status: complete
+---
+
+# Summary: Fix mobile GroupPicker index white-page bug
+
+**Note:** This SUMMARY.md was reconstructed by the orchestrator from the executor agent's final report — the original was created inside an isolated worktree and lost when the worktree was removed before the file could be rescued. Commit contents, verification results, and the deviation note below are taken verbatim from the executor's completion report.
+
+## Root Cause
+
+`Index.Mobile.cshtml` (served to mobile User-Agents via `MobileViewLocationExpander`) declares `@section Styles { <link ~/css/account.mobile.css> }` and uses `_Layout.GroupPicker.cshtml` as its layout. That layout's `<head>` had no `RenderSectionAsync("Styles", ...)` call, so Razor threw `InvalidOperationException: The following sections have been defined but have not been rendered ... 'Styles'` — surfacing to the user as a blank white page. Desktop `Index.cshtml` uses the same layout but defines no `Styles` section, which is why desktop was unaffected. The layout already rendered `Scripts` correctly — `Styles` was the only gap.
+
+## Tasks Completed
+
+1. **Render the Styles section in the GroupPicker layout head** — added `@await RenderSectionAsync("Styles", required: false)` to `QuestBoard.Service/Views/Shared/_Layout.GroupPicker.cshtml`, matching the established convention in the sibling `_Layout.Mobile.cshtml`. `required: false` keeps desktop's `Index.cshtml` (no Styles section) working.
+2. **Mobile GroupPicker regression test** — added `MobileGroupPicker_MobileUserAgent_RendersGroupCardsAndStylesSection` to `QuestBoard.IntegrationTests/Mobile/MobileViewsTests.cs`: authenticated mobile-UA GET to `/GroupPicker/Index` asserts `200 OK` and that the HTML contains both `account-card-mobile` and `account.mobile.css`.
+
+## Commits
+
+- `d52b89a` — fix(quick-260702-t9m): render Styles section in GroupPicker layout head
+- `2e5af67` — test(quick-260702-t9m): add mobile GroupPicker regression test
+
+## Verification
+
+- Full `dotnet build` (6 projects): 0 errors.
+- Full mobile test suite: 67/67 passed.
+- Full `QuestBoard.IntegrationTests` suite: 232/232 passed.
+- Executor manually confirmed the regression guard is real: temporarily reverted the layout fix, re-ran the new test, and observed it fail with the exact `"sections have been defined but have not been rendered ... 'Styles'"` exception; restored the fix and confirmed the test passes cleanly.
+
+## Deviations
+
+The first two attempts at the regression test produced false positives before the final version landed:
+- The unauthenticated/misrouted request redirected to `/Account/Login`, whose mobile view coincidentally shares the `account-card-mobile` / `account.mobile.css` markers with the real target — masking a non-passing case as a pass.
+- A naive `Max(Id)+1` group-seeding strategy collided with a dangling `GroupId=1` FK reference that `AuthenticationHelper` creates without a matching `GroupEntity` row.
+
+Both were fixed before the final commit; no other deviations from the plan.

--- a/QuestBoard.IntegrationTests/Mobile/MobileViewsTests.cs
+++ b/QuestBoard.IntegrationTests/Mobile/MobileViewsTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Headers;
+using QuestBoard.Domain.Enums;
 using QuestBoard.IntegrationTests.Helpers;
 
 namespace QuestBoard.IntegrationTests.Mobile;
@@ -493,6 +494,54 @@ public class MobileViewsTests : IClassFixture<WebApplicationFactoryBase>
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         html.Should().Contain("account-card-mobile");
+    }
+
+    /// <summary>
+    /// Mobile UA on /GroupPicker/Index renders the group-selection cards and links
+    /// account.mobile.css. Guards against the unrendered-Styles-section white-page regression:
+    /// Index.Mobile.cshtml defines a Styles section that _Layout.GroupPicker.cshtml must render.
+    /// The test user is seeded into two groups so the controller returns the card-picker view
+    /// instead of auto-redirecting (which happens when a user belongs to exactly one group).
+    /// </summary>
+    [Fact]
+    public async Task MobileGroupPicker_MobileUserAgent_RendersGroupCardsAndStylesSection()
+    {
+        var (authClient, gpUser) = await AuthenticationHelper.CreateAuthenticatedClientWithUserAsync(
+            _factory, "gp_mobile01", "gp_mobile01@test.com");
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var context = scope.ServiceProvider.GetRequiredService<QuestBoardContext>();
+
+            // AuthenticationHelper seeds a UserGroups row referencing GroupId=1, but does not
+            // guarantee a matching GroupEntity row exists (this test class does not call
+            // TestDataHelper.SeedDefaultGroupAsync). Ensure it exists so GroupId=1 is a real,
+            // queryable group rather than a dangling FK reference the InMemory provider silently allows.
+            if (!await context.Groups.AnyAsync(g => g.Id == 1, TestContext.Current.CancellationToken))
+            {
+                context.Groups.Add(new GroupEntity { Id = 1, Name = "EuphoriaInn", CreatedAt = DateTime.UtcNow });
+            }
+
+            // Use a random large Id for the second group so it cannot collide with Id=1 or with
+            // groups created by other tests sharing this class fixture's database.
+            var secondGroupId = Random.Shared.Next(100_000, 999_999);
+            var secondGroup = new GroupEntity { Id = secondGroupId, Name = $"GroupPickerTest_{Guid.NewGuid():N}", CreatedAt = DateTime.UtcNow };
+            context.Groups.Add(secondGroup);
+
+            context.UserGroups.Add(new UserGroupEntity { UserId = gpUser.Id, GroupId = 1, GroupRole = (int)GroupRole.Player });
+            context.UserGroups.Add(new UserGroupEntity { UserId = gpUser.Id, GroupId = secondGroupId, GroupRole = (int)GroupRole.Player });
+            await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "/GroupPicker/Index");
+        request.Headers.TryAddWithoutValidation("User-Agent", MobileUserAgent);
+        request.Headers.Authorization = authClient.DefaultRequestHeaders.Authorization;
+        var response = await _client.SendAsync(request, TestContext.Current.CancellationToken);
+        var html = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        html.Should().Contain("account-card-mobile");
+        html.Should().Contain("account.mobile.css");
     }
 
     /// <summary>

--- a/QuestBoard.Service/Views/Shared/_Layout.GroupPicker.cshtml
+++ b/QuestBoard.Service/Views/Shared/_Layout.GroupPicker.cshtml
@@ -8,6 +8,7 @@
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
+    @await RenderSectionAsync("Styles", required: false)
 </head>
 <body class="d-flex flex-column min-vh-100">
 


### PR DESCRIPTION
## Summary

- Mobile users hitting `/GroupPicker/Index` saw a blank white page. Root cause: `Index.Mobile.cshtml` defines `@section Styles { ... }` for `account.mobile.css`, but its layout `_Layout.GroupPicker.cshtml` never called `RenderSectionAsync("Styles", ...)`, so Razor threw `InvalidOperationException: The following sections have been defined but have not been rendered ... 'Styles'` on every mobile request. Desktop was unaffected since `Index.cshtml` defines no `Styles` section.
- Fix: added `@await RenderSectionAsync("Styles", required: false)` to the layout's `<head>`, matching the existing convention in `_Layout.Mobile.cshtml`.
- Added a regression test (`MobileGroupPicker_MobileUserAgent_RendersGroupCardsAndStylesSection`) that drives an authenticated mobile-UA GET to `/GroupPicker/Index` and asserts a 200 with both `account-card-mobile` and `account.mobile.css` present. Manually confirmed it fails with the pre-fix exception when the layout change is reverted.

## Test plan

- [x] `dotnet build` — 6 projects, 0 errors
- [x] Full mobile test suite — 67/67 passed
- [x] Full `QuestBoard.IntegrationTests` suite — 232/232 passed
- [x] Verified the new test fails against the pre-fix layout and passes against the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)