### PR TITLE
Add mobile views for Platform area (Group management)

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -47,6 +47,7 @@ Items acknowledged and deferred at milestone close on 2026-07-02:
 | # | Description | Date | Commit | Directory |
 |---|-------------|------|--------|-----------|
 | 260702-t9m | Fix mobile GroupPicker index white-page bug caused by unrendered Styles section in _Layout.GroupPicker.cshtml | 2026-07-02 | 82aa549 | [260702-t9m-fix-mobile-grouppicker-index-white-page-](./quick/260702-t9m-fix-mobile-grouppicker-index-white-page-/) |
+| 260702-tz2 | Add mobile (.Mobile.cshtml) views for the Platform area's Group management pages (Index, Create, Edit, Delete, Members), matching existing mobile styling conventions | 2026-07-02 | 9c2ad2a | [260702-tz2-the-area-platform-view-don-t-have-a-mobi](./quick/260702-tz2-the-area-platform-view-don-t-have-a-mobi/) |
 
 ## Accumulated Context
 
@@ -68,4 +69,4 @@ Last session: 2026-07-02T13:00:01.218Z
 Stopped at: v5.0 milestone archived
 Next step: `/gsd:new-milestone`
 
-Last activity: 2026-07-02 - Completed quick task 260702-t9m: Fix mobile GroupPicker index white-page bug caused by unrendered Styles section in _Layout.GroupPicker.cshtml
+Last activity: 2026-07-02 - Completed quick task 260702-tz2: Add mobile views for the Platform area's Group management pages (Index, Create, Edit, Delete, Members)

--- a/.planning/quick/260702-tz2-the-area-platform-view-don-t-have-a-mobi/260702-tz2-PLAN.md
+++ b/.planning/quick/260702-tz2-the-area-platform-view-don-t-have-a-mobi/260702-tz2-PLAN.md
@@ -1,0 +1,230 @@
+---
+phase: quick-260702-tz2
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - QuestBoard.Service/Areas/Platform/Views/Shared/_Layout.Platform.Mobile.cshtml
+  - QuestBoard.Service/wwwroot/css/platform-group.mobile.css
+  - QuestBoard.Service/Areas/Platform/Views/Group/Index.Mobile.cshtml
+  - QuestBoard.Service/Areas/Platform/Views/Group/Create.Mobile.cshtml
+  - QuestBoard.Service/Areas/Platform/Views/Group/Edit.Mobile.cshtml
+  - QuestBoard.Service/Areas/Platform/Views/Group/Delete.Mobile.cshtml
+  - QuestBoard.Service/Areas/Platform/Views/Group/Members.Mobile.cshtml
+autonomous: true
+requirements: [QB-QUICK-TZ2]
+
+must_haves:
+  truths:
+    - "On a mobile device, Platform area pages render inside a mobile layout (offcanvas hamburger nav), not the desktop Platform navbar"
+    - "Group list renders as stacked glass sub-cards (no table) on mobile, with Members/Edit/Delete actions per group"
+    - "Create, Edit, and Delete Group forms render inside a glass card on mobile with the same fields/actions as desktop"
+    - "Members page renders member sub-cards + the Add Member form inside glass cards on mobile"
+    - "Every existing desktop Platform flow still works unchanged (no desktop file modified)"
+  artifacts:
+    - path: "QuestBoard.Service/Areas/Platform/Views/Shared/_Layout.Platform.Mobile.cshtml"
+      provides: "Mobile Platform layout with offcanvas nav, mobile.css, footer"
+      contains: "offcanvas"
+    - path: "QuestBoard.Service/wwwroot/css/platform-group.mobile.css"
+      provides: "Shared glass-card + sub-card + form styling for all 5 Platform Group mobile views"
+      contains: "backdrop-filter"
+    - path: "QuestBoard.Service/Areas/Platform/Views/Group/Index.Mobile.cshtml"
+      provides: "Mobile group list as stacked sub-cards"
+      contains: "platform-group.mobile.css"
+    - path: "QuestBoard.Service/Areas/Platform/Views/Group/Create.Mobile.cshtml"
+      provides: "Mobile create-group form in glass card"
+      contains: "platform-group.mobile.css"
+    - path: "QuestBoard.Service/Areas/Platform/Views/Group/Edit.Mobile.cshtml"
+      provides: "Mobile edit-group form in glass card"
+      contains: "platform-group.mobile.css"
+    - path: "QuestBoard.Service/Areas/Platform/Views/Group/Delete.Mobile.cshtml"
+      provides: "Mobile delete-group confirmation in glass card"
+      contains: "platform-group.mobile.css"
+    - path: "QuestBoard.Service/Areas/Platform/Views/Group/Members.Mobile.cshtml"
+      provides: "Mobile members list sub-cards + Add Member form"
+      contains: "platform-group.mobile.css"
+  key_links:
+    - from: "Areas/Platform/Views/_ViewStart.cshtml"
+      to: "_Layout.Platform.Mobile.cshtml"
+      via: "MobileViewLocationExpander rewrites _Layout.Platform -> _Layout.Platform.Mobile when IsMobile"
+      pattern: "_Layout\\.Platform"
+    - from: "Group/*.Mobile.cshtml @section Styles"
+      to: "platform-group.mobile.css"
+      via: "link asp-append-version"
+      pattern: "platform-group\\.mobile\\.css"
+---
+
+<objective>
+Create mobile (`.Mobile.cshtml`) counterparts for every view in the Platform area, plus the missing mobile Platform layout and a shared companion stylesheet, so Platform admin pages render correctly on phones instead of falling back to the desktop layout.
+
+Purpose: The Platform area (Group management) is the only area with no mobile views. `MobileViewLocationExpander` already rewrites `Foo.cshtml -> Foo.Mobile.cshtml` (views AND layouts) when `HttpContext.Items["IsMobile"]` is true, but no mobile files exist for Platform, so mobile users get the desktop layout and non-responsive tables. This plan is purely additive — it creates sibling files only.
+
+Output: 7 new files (1 mobile layout, 1 shared CSS, 5 mobile views). Zero changes to desktop views, controllers, routing, or C#.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/STATE.md
+@CLAUDE.md
+
+# Mechanism (no C# needed — expander already wired):
+@QuestBoard.Service/ViewExpanders/MobileViewLocationExpander.cs
+
+# Desktop originals to mirror EXACTLY (same model, same actions, same data):
+@QuestBoard.Service/Areas/Platform/Views/Group/Index.cshtml
+@QuestBoard.Service/Areas/Platform/Views/Group/Create.cshtml
+@QuestBoard.Service/Areas/Platform/Views/Group/Edit.cshtml
+@QuestBoard.Service/Areas/Platform/Views/Group/Delete.cshtml
+@QuestBoard.Service/Areas/Platform/Views/Group/Members.cshtml
+@QuestBoard.Service/Areas/Platform/Views/Shared/_Layout.Platform.cshtml
+
+# Conventions to copy (mobile layout shell, glass-card view + CSS, form view):
+@QuestBoard.Service/Views/Shared/_Layout.Mobile.cshtml
+@QuestBoard.Service/Views/Admin/Users.Mobile.cshtml
+@QuestBoard.Service/wwwroot/css/admin-users.mobile.css
+@QuestBoard.Service/Views/ShopManagement/Create.Mobile.cshtml
+@QuestBoard.Service/wwwroot/css/shop-management-create.mobile.css
+
+<interfaces>
+<!-- These directives are ALREADY in Areas/Platform/Views/_ViewImports.cshtml and apply to
+     every .cshtml (including .Mobile.cshtml) in the Platform area. Mobile views need NO extra @using. -->
+Available in scope for all Platform Group mobile views:
+- @using QuestBoard.Domain.Enums          -> GroupRole (GroupRole.Admin | GroupRole.DungeonMaster | GroupRole.Player)
+- @using QuestBoard.Domain.Models          -> Group (used as @model in Delete.cshtml)
+- @using QuestBoard.Service.ViewModels.PlatformViewModels -> GroupListViewModel, GroupCreateViewModel, GroupEditViewModel, GroupMembersViewModel
+- @inject IAuthorizationService AuthorizationService
+- Tag helpers (asp-*) are registered
+
+Models per view (copy @model line verbatim from the desktop original):
+- Index.cshtml    -> @model GroupListViewModel      (Model.Groups: each item has Id, Name, MemberCount, CreatedAt)
+- Create.cshtml   -> @model GroupCreateViewModel     (Name)
+- Edit.cshtml     -> @model GroupEditViewModel        (Id hidden, Name)
+- Delete.cshtml   -> @model Group                     (Model.Id, Model.Name)
+- Members.cshtml  -> @model GroupMembersViewModel     (Model.Group.{Id,Name}; Model.Members: each has User?.Name, User?.Email, GroupRole, UserId; Model.AvailableUsers: Id, Name, Email; Model.AddMember.{UserId,Role})
+
+_ViewStart.cshtml sets Layout = "_Layout.Platform" for the whole area. The expander swaps this to
+"_Layout.Platform.Mobile" on mobile — so the mobile layout filename MUST be exactly
+_Layout.Platform.Mobile.cshtml in Areas/Platform/Views/Shared/.
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Create the mobile Platform layout</name>
+  <files>QuestBoard.Service/Areas/Platform/Views/Shared/_Layout.Platform.Mobile.cshtml</files>
+  <action>
+Create `_Layout.Platform.Mobile.cshtml` modeled on the site-wide `Views/Shared/_Layout.Mobile.cshtml` shell but carrying ONLY the Platform area's nav items (do NOT add guild/quest/shop/calendar items — those belong to the main site, not the Platform admin area).
+
+Structure to reproduce from `_Layout.Mobile.cshtml`:
+- Same `<head>`: bootstrap CDN, font-awesome CDN, Cinzel font, then `<link rel="stylesheet" href="~/css/mobile.css" asp-append-version="true" />`, then `@await RenderSectionAsync("Styles", required: false)`. Title should read `@ViewData["Title"] - D&D Quest Board Platform` (match the desktop Platform layout's title suffix).
+- `<body class="d-flex flex-column min-vh-100 mobile-layout @ViewData["BodyClass"]">`.
+- `<header>` with `navbar navbar-dark bg-dark py-2` containing a `container-fluid px-3`: the brand `<a class="navbar-brand" asp-controller="Group" asp-action="Index" asp-area="Platform"><i class="fas fa-dice-d20"></i> D&D Quest Board</a>` and the offcanvas toggle button (`navbar-toggler`, `data-bs-toggle="offcanvas"`, `data-bs-target="#platformMobileNav"`).
+- An `offcanvas offcanvas-end` element with `id="platformMobileNav"`, an offcanvas-header (`bg-dark text-white`) with title `<i class="fas fa-dice-d20 me-2"></i>Platform` and a `btn-close btn-close-white` dismiss button, and an offcanvas-body containing a `<ul class="navbar-nav">` with EXACTLY these items, mirroring the desktop Platform navbar links:
+  1. Current user display: `<li class="nav-item"><span class="navbar-text text-light"><i class="fas fa-user me-2"></i>@User.Identity?.Name</span></li>`
+  2. Back to quest board: `<a class="nav-link" asp-controller="Home" asp-action="Index" asp-area=""><i class="fas fa-arrow-left me-2"></i>Back to quest board</a>`
+  3. Logout: a `<form asp-controller="Account" asp-action="Logout" asp-area="" method="post">` with `<button type="submit" class="nav-link btn btn-link text-start w-100" data-bs-dismiss="offcanvas"><i class="fas fa-sign-out-alt me-2"></i>Logout</button>` (copy the exact logout button pattern from `_Layout.Mobile.cshtml` lines 133-140, but add `asp-area=""` so it targets the root-area Account controller like the desktop Platform layout does).
+- `<main class="container-fluid px-2 mt-2">@RenderBody()</main>`.
+- The same `<footer>` block as `_Layout.Mobile.cshtml` (navbar-dark bg-dark mt-auto, "D&D Quest Board. Created by Theun Schut." + github brand link).
+- Same closing scripts: jQuery CDN, bootstrap bundle CDN, `~/js/site.js` asp-append-version, then `@await RenderSectionAsync("Scripts", required: false)`.
+
+Do NOT include the `@inject IHttpContextAccessor` / SessionKeys / GroupPicker / UserService calls from `_Layout.Mobile.cshtml` — the Platform layout is simpler (see the desktop `_Layout.Platform.cshtml`, which only uses `@User.Identity?.Name`). Do NOT add a `@model`. The `_ViewImports.cshtml` already provides `AuthorizationService` and tag helpers, but this layout does not need role-gated nav so no authorize calls are required.
+  </action>
+  <verify>
+    <automated>test -f "QuestBoard.Service/Areas/Platform/Views/Shared/_Layout.Platform.Mobile.cshtml" && grep -q 'platformMobileNav' "QuestBoard.Service/Areas/Platform/Views/Shared/_Layout.Platform.Mobile.cshtml" && grep -q 'mobile-layout' "QuestBoard.Service/Areas/Platform/Views/Shared/_Layout.Platform.Mobile.cshtml" && grep -q 'css/mobile.css' "QuestBoard.Service/Areas/Platform/Views/Shared/_Layout.Platform.Mobile.cshtml" && grep -q 'Back to quest board' "QuestBoard.Service/Areas/Platform/Views/Shared/_Layout.Platform.Mobile.cshtml"</automated>
+  </verify>
+  <done>Mobile Platform layout file exists with offcanvas hamburger nav (id platformMobileNav), mobile-layout body class, mobile.css link, brand -> Group/Index, current-user display, "Back to quest board" link, Logout form (asp-area=""), main container-fluid, and footer. No desktop file touched.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Create the shared companion stylesheet</name>
+  <files>QuestBoard.Service/wwwroot/css/platform-group.mobile.css</files>
+  <action>
+Create `platform-group.mobile.css`, one shared stylesheet loaded by all 5 Platform Group mobile views (Task 3). Follow the exact convention of `admin-users.mobile.css` and `shop-management-create.mobile.css`.
+
+Start with the two-line header comment convention:
+- Line 1: `/* platform-group.mobile.css - Platform Group mobile views (Index, Create, Edit, Delete, Members) */`
+- Line 2: `/* No @media queries — exclusively loaded by Areas/Platform/Views/Group/*.Mobile.cshtml via _Layout.Platform.Mobile.cshtml */`
+
+Then define these rules (glass styling values copied verbatim from `admin-users.mobile.css` — background rgba(255,255,255,0.15), backdrop-filter blur(15px), border 1px solid rgba(255,255,255,0.3), border-radius 12px, box-shadow 0 8px 32px rgba(0,0,0,0.2)):
+
+1. `.platform-group-card-mobile` — the root container glass card, `padding: 16px;` (this class wraps every mobile view's content).
+2. `.group-card-mobile` — the per-row sub-card used in Index and Members lists, same glass styling but `padding: 12px;`.
+3. Parchment headings/labels — a combined selector `.platform-group-card-mobile h5, .platform-group-card-mobile .form-label, .platform-group-card-mobile .parchment-text` with `color: #F4E4BC !important;` and `text-shadow: 2px 2px 4px rgba(0,0,0,0.9), -1px -1px 2px rgba(0,0,0,0.9);`.
+4. Body/paragraph text inside the card readable on the dark background — `.platform-group-card-mobile p` with `color: #F4E4BC !important;` and the same strong text-shadow (Delete confirmation prose and empty-state hints must stay legible; keep the `.text-muted`/`small` faded handling below for helper text).
+5. Small/help/muted text — `.platform-group-card-mobile small, .platform-group-card-mobile .form-text, .platform-group-card-mobile .text-muted` with `color: rgba(244, 228, 188, 0.7) !important;` and `text-shadow: 1px 1px 3px rgba(0, 0, 0, 0.9) !important;`.
+6. Badges — `.platform-group-card-mobile .badge` with `text-shadow: none !important;` so role badges stay legible.
+7. Muted empty-state icons — `.platform-group-card-mobile .fa-3x.text-muted { color: rgba(244, 228, 188, 0.7) !important; }` so the empty-state icons still read on the dark background (kept separate so it does not conflict with the small-text muted color rule).
+
+Do NOT add any `@media` query — this file is only ever loaded when a mobile view renders. Match the flat, comment-then-rules formatting of the two reference CSS files.
+  </action>
+  <verify>
+    <automated>test -f "QuestBoard.Service/wwwroot/css/platform-group.mobile.css" && grep -q 'platform-group-card-mobile' "QuestBoard.Service/wwwroot/css/platform-group.mobile.css" && grep -q 'group-card-mobile' "QuestBoard.Service/wwwroot/css/platform-group.mobile.css" && grep -q 'backdrop-filter' "QuestBoard.Service/wwwroot/css/platform-group.mobile.css" && ! grep -q '@media' "QuestBoard.Service/wwwroot/css/platform-group.mobile.css"</automated>
+  </verify>
+  <done>Shared CSS exists with header comment, `.platform-group-card-mobile` root card (padding 16px), `.group-card-mobile` sub-card (padding 12px), parchment heading/label/paragraph rules, faded small/help/muted text, empty-state icon color, badges with no text-shadow, and zero `@media` queries.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Create the 5 Platform Group mobile views</name>
+  <files>QuestBoard.Service/Areas/Platform/Views/Group/Index.Mobile.cshtml, QuestBoard.Service/Areas/Platform/Views/Group/Create.Mobile.cshtml, QuestBoard.Service/Areas/Platform/Views/Group/Edit.Mobile.cshtml, QuestBoard.Service/Areas/Platform/Views/Group/Delete.Mobile.cshtml, QuestBoard.Service/Areas/Platform/Views/Group/Members.Mobile.cshtml</files>
+  <action>
+Create all 5 mobile views. Each MUST: copy the `@model` line verbatim from its desktop original, keep the same `ViewData["Title"]` block, keep every form action / route / hidden field / model binding / conditional exactly as desktop (same data, same actions — mobile only restyles), and open with a `@section Styles { <link href="~/css/platform-group.mobile.css" asp-append-version="true" rel="stylesheet" /> }` block. Every view's content wraps in `<div class="platform-group-card-mobile mb-3">...</div>` (the glass card). Use `<h5>` headings with a FontAwesome icon (+ `me-2`) instead of the desktop `<h2>` modern-card-header. Do NOT reference `modern-card`/`modern-card-header`/`modern-card-body` classes in mobile views. Do NOT add extra `@using` (the area `_ViewImports` covers everything). Do NOT emit any GSD/phase/requirement IDs in comments per CLAUDE.md.
+
+Per-view detail:
+
+**Index.Mobile.cshtml** (`@model GroupListViewModel`) — model after `Views/Admin/Users.Mobile.cshtml`:
+- Inside `.platform-group-card-mobile`: a header row `d-flex justify-content-between align-items-center mb-3` with `<h5 class="mb-0"><i class="fas fa-layer-group text-danger me-2"></i>Group Management</h5>` and the Create button `<a asp-controller="Group" asp-action="Create" asp-area="Platform" class="btn btn-success btn-sm"><i class="fas fa-plus me-2"></i>Create Group</a>`.
+- Keep both TempData Success/Error alert blocks exactly as desktop (place them right after the header row, before the list).
+- If `Model.Groups.Any()`: `@foreach (var item in Model.Groups)` render a `<div class="group-card-mobile mb-3">` containing: a name/meta block — `<strong class="parchment-text">@item.Name</strong>`, then a `<small>` line showing member count and created date, e.g. `Members: @item.MemberCount · Created: @item.CreatedAt.ToString("yyyy-MM-dd")` — then a `<div class="d-flex flex-wrap gap-2 mt-2">` with the action buttons ported from desktop: Members (`btn btn-sm btn-info`, icon `fa-users`), Edit (`btn btn-sm btn-warning`, icon `fa-edit`), and Delete ONLY when `@item.MemberCount == 0` (`btn btn-sm btn-danger`, icon `fa-trash`) — each keeping the same `asp-controller/asp-action/asp-area="Platform"/asp-route-id="@item.Id"` as desktop.
+- Else: keep the desktop empty-state block (`py-5 text-center`, `fa-layer-group fa-3x text-muted mb-3`, "No groups yet." strong + muted "Create the first group to get started.").
+
+**Create.Mobile.cshtml** (`@model GroupCreateViewModel`) — model after `Views/ShopManagement/Create.Mobile.cshtml`:
+- Inside `.platform-group-card-mobile`: `<h5 class="mb-0"><i class="fas fa-plus-circle text-danger me-2"></i>Create Group</h5>` in a `mb-3` block, then the desktop form verbatim (`asp-action="Create" method="post"`, `asp-validation-summary="ModelOnly"`, the Name `form-label`/`form-control`/validation span), `<hr>`, and the `d-flex justify-content-between` action row: secondary "Back to Groups" link (`asp-action="Index" asp-area="Platform"`) left, success "Create Group" submit right — identical buttons to desktop.
+
+**Edit.Mobile.cshtml** (`@model GroupEditViewModel`):
+- Same shape as Create.Mobile but: heading `<i class="fas fa-edit text-danger me-2"></i>Edit Group`; form `asp-action="Edit"`; include the `<input asp-for="Id" type="hidden" />`; the Name field; `<hr>`; action row with secondary "Back to Groups" left and warning "Save Changes" (`btn btn-warning`, `fa-save`) right — matching desktop exactly.
+
+**Delete.Mobile.cshtml** (`@model Group`):
+- Inside `.platform-group-card-mobile`: `<h5 class="mb-0"><i class="fas fa-trash text-danger me-2"></i>Delete Group</h5>`, then the confirmation paragraph `<p>Are you sure you want to delete the group <strong>"@Model.Name"</strong>? This action cannot be undone.</p>`, then the form `asp-action="Delete" method="post" asp-route-id="@Model.Id"`, `<hr>`, and the action row: secondary "Back to Groups" left, danger "Delete Group" (`btn btn-danger`, `fa-trash`) right — identical to desktop.
+
+**Members.Mobile.cshtml** (`@model GroupMembersViewModel`) — list part after `Users.Mobile.cshtml`, form part after `ShopManagement/Create.Mobile.cshtml`:
+- Inside `.platform-group-card-mobile`: `<h5 class="mb-0"><i class="fas fa-users text-danger me-2"></i>Members &mdash; @Model.Group.Name</h5>`.
+- Keep both TempData Success/Error alert blocks exactly as desktop.
+- "Back to Groups" secondary button (`asp-controller="Group" asp-action="Index" asp-area="Platform"`, `fa-arrow-left`), placed in a `mb-3`.
+- If `Model.Members.Any()`: `@foreach (var member in Model.Members)` render a `<div class="group-card-mobile mb-3">` with: `<strong class="parchment-text">@(member.User?.Name ?? "Unknown")</strong>`, a `<small>` line for `@(member.User?.Email ?? "")`, the role badge block ported verbatim from desktop (the same `@if (member.GroupRole == GroupRole.Admin) { bg-danger fa-shield-alt Admin } else if (== GroupRole.DungeonMaster) { bg-warning text-dark fa-crown DungeonMaster } else { bg-primary fa-dice-d20 Player }`), and a `d-flex flex-wrap gap-2 mt-2` row containing the RemoveMember form verbatim (`asp-action="RemoveMember" asp-route-id="@Model.Group.Id" method="post" asp-antiforgery="true"`, hidden `userId` = `@member.UserId`, danger submit `fa-user-minus Remove Member`).
+- Else: desktop empty-state (`py-5 text-center`, `fa-users fa-3x text-muted mb-3`, muted "No members in this group yet.").
+- `<hr>` then `<h5><i class="fas fa-user-plus text-danger me-2"></i>Add Member</h5>`.
+- If `Model.AvailableUsers.Any()`: the desktop Add Member form verbatim (`asp-action="AddMember" asp-route-id="@Model.Group.Id" method="post" asp-antiforgery="true"`) — the User `<select asp-for="AddMember.UserId" class="form-select">` populated from `Model.AvailableUsers`, the Role `<select asp-for="AddMember.Role" asp-items="Html.GetEnumSelectList<GroupRole>()">`, their validation spans and `form-label`s, and the success "Add to Group" submit (`fa-user-plus`).
+- Else: `<p class="text-muted fst-italic">All users are already members of this group.</p>`.
+  </action>
+  <verify>
+    <automated>bash -c 'for f in Index Create Edit Delete Members; do p="QuestBoard.Service/Areas/Platform/Views/Group/$f.Mobile.cshtml"; test -f "$p" || { echo "MISSING $p"; exit 1; }; grep -q "platform-group.mobile.css" "$p" || { echo "NO CSS LINK $p"; exit 1; }; grep -q "platform-group-card-mobile" "$p" || { echo "NO CARD $p"; exit 1; }; grep -q "modern-card" "$p" && { echo "STRAY modern-card in $p"; exit 1; }; done; echo OK'</automated>
+  </verify>
+  <done>All 5 mobile view files exist, each links platform-group.mobile.css, wraps content in .platform-group-card-mobile, uses no modern-card classes, copies its desktop @model and all form actions/routes/hidden fields/badges verbatim, and lists become .group-card-mobile stacked sub-cards. Solution builds (`dotnet build`) with no new warnings.</done>
+</task>
+
+</tasks>
+
+<verification>
+After all tasks:
+- `dotnet build` succeeds (confirm no C#/project-file changes were introduced — Razor views compile at runtime, but the build must not break).
+- `git status` shows ONLY 7 new files under `QuestBoard.Service/Areas/Platform/Views/...` and `QuestBoard.Service/wwwroot/css/platform-group.mobile.css` — zero modified desktop files, controllers, or `.csproj`.
+- Manual mobile smoke (optional, human): load `/Platform/Group` in a mobile viewport / device — page renders inside the offcanvas-hamburger Platform layout, groups show as stacked glass sub-cards, Create/Edit/Delete/Members forms render inside glass cards. Desktop viewport is unchanged.
+</verification>
+
+<success_criteria>
+- 7 new files created (1 mobile layout, 1 shared CSS, 5 mobile views); no existing file modified.
+- `MobileViewLocationExpander` resolves `_Layout.Platform -> _Layout.Platform.Mobile` and `Group/X -> Group/X.Mobile` on mobile (no code change needed — mechanism already exists).
+- Each mobile view preserves its desktop counterpart's model, data, form actions, routes, and role badges exactly — only presentation differs.
+- Styling matches established mobile conventions: glass card container, per-row sub-cards for lists, parchment text/shadows, faded help text, badges without text-shadow, shared companion CSS with no `@media` queries.
+- Buttons follow CLAUDE.md UI guidance: filled colored buttons, FA icons with `me-2`, `d-flex justify-content-between` action rows (cancel left, submit right), `<hr>` before form action rows.
+</success_criteria>
+
+<output>
+Create `.planning/quick/260702-tz2-the-area-platform-view-don-t-have-a-mobi/260702-tz2-SUMMARY.md` when done.
+</output>

--- a/.planning/quick/260702-tz2-the-area-platform-view-don-t-have-a-mobi/260702-tz2-SUMMARY.md
+++ b/.planning/quick/260702-tz2-the-area-platform-view-don-t-have-a-mobi/260702-tz2-SUMMARY.md
@@ -1,0 +1,109 @@
+---
+phase: quick-260702-tz2
+plan: 01
+subsystem: ui
+tags: [razor-views, mobile-responsive, mvc-areas, bootstrap-offcanvas]
+
+requires:
+  - phase: none
+    provides: n/a — purely additive sibling files, no dependency on other phases
+provides:
+  - Mobile Platform layout with offcanvas hamburger nav (_Layout.Platform.Mobile.cshtml)
+  - Shared companion stylesheet for all Platform Group mobile views (platform-group.mobile.css)
+  - 5 mobile views for Platform Group management (Index, Create, Edit, Delete, Members)
+affects: [platform-area, mobile-ui]
+
+tech-stack:
+  added: []
+  patterns:
+    - "MobileViewLocationExpander convention: Foo.cshtml sibling Foo.Mobile.cshtml resolved automatically when HttpContext.Items[\"IsMobile\"] is true — no C# routing changes needed"
+    - "Glass-card mobile styling: .{area}-card-mobile root container + .{item}-card-mobile per-row sub-card, both using rgba(255,255,255,0.15) background + backdrop-filter blur(15px)"
+
+key-files:
+  created:
+    - QuestBoard.Service/Areas/Platform/Views/Shared/_Layout.Platform.Mobile.cshtml
+    - QuestBoard.Service/wwwroot/css/platform-group.mobile.css
+    - QuestBoard.Service/Areas/Platform/Views/Group/Index.Mobile.cshtml
+    - QuestBoard.Service/Areas/Platform/Views/Group/Create.Mobile.cshtml
+    - QuestBoard.Service/Areas/Platform/Views/Group/Edit.Mobile.cshtml
+    - QuestBoard.Service/Areas/Platform/Views/Group/Delete.Mobile.cshtml
+    - QuestBoard.Service/Areas/Platform/Views/Group/Members.Mobile.cshtml
+  modified: []
+
+key-decisions:
+  - "Mobile Platform layout omits IHttpContextAccessor/SessionKeys/GroupPicker/UserService — the desktop _Layout.Platform.cshtml is simpler than the site-wide layout (only @User.Identity?.Name), so the mobile counterpart mirrors that simplicity rather than the richer site-wide _Layout.Mobile.cshtml nav"
+  - "Logout form in mobile Platform layout uses asp-area=\"\" to target the root-area Account controller, matching desktop Platform layout's logout behavior"
+
+requirements-completed: [QB-QUICK-TZ2]
+
+duration: 15min
+completed: 2026-07-02
+---
+
+# Phase quick-260702-tz2: Mobile Platform Group Views Summary
+
+**Added the missing mobile layout, shared glass-card CSS, and 5 mobile views for the Platform area's Group management pages, so phone users get an offcanvas-nav layout and stacked sub-cards instead of falling back to the desktop navbar/table.**
+
+## Performance
+
+- **Duration:** ~15 min
+- **Completed:** 2026-07-02T19:47:32Z
+- **Tasks:** 3
+- **Files modified:** 7 (all new; zero existing files touched)
+
+## Accomplishments
+- Mobile Platform layout (`_Layout.Platform.Mobile.cshtml`) with offcanvas hamburger nav, mirroring the site-wide mobile shell but scoped to only the Platform area's 3 nav items (current user, back to quest board, logout)
+- Shared companion stylesheet (`platform-group.mobile.css`) providing glass-card container, per-row sub-card, parchment text/labels, faded help text, badges without text-shadow, and muted empty-state icon styling — reused by all 5 mobile views
+- 5 mobile views (Index, Create, Edit, Delete, Members) each preserving their desktop counterpart's `@model`, form actions, routes, hidden fields, and role badges verbatim — only presentation differs (glass cards + stacked sub-cards instead of Bootstrap tables)
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Create the mobile Platform layout** - `4e00e83` (feat)
+2. **Task 2: Create the shared companion stylesheet** - `5b5c5c4` (feat)
+3. **Task 3: Create the 5 Platform Group mobile views** - `cce72ee` (feat)
+
+**Plan metadata:** committed separately by orchestrator (docs commit not included here per instructions)
+
+## Files Created/Modified
+- `QuestBoard.Service/Areas/Platform/Views/Shared/_Layout.Platform.Mobile.cshtml` - Mobile Platform layout: offcanvas hamburger nav (`#platformMobileNav`), mobile.css, footer, brand -> Group/Index
+- `QuestBoard.Service/wwwroot/css/platform-group.mobile.css` - Shared glass-card + sub-card + parchment-text styling for all 5 Platform Group mobile views
+- `QuestBoard.Service/Areas/Platform/Views/Group/Index.Mobile.cshtml` - Group list as stacked `.group-card-mobile` sub-cards with Members/Edit/Delete actions
+- `QuestBoard.Service/Areas/Platform/Views/Group/Create.Mobile.cshtml` - Create-group form in glass card
+- `QuestBoard.Service/Areas/Platform/Views/Group/Edit.Mobile.cshtml` - Edit-group form in glass card
+- `QuestBoard.Service/Areas/Platform/Views/Group/Delete.Mobile.cshtml` - Delete-group confirmation in glass card
+- `QuestBoard.Service/Areas/Platform/Views/Group/Members.Mobile.cshtml` - Member sub-cards + Add Member form in glass cards
+
+## Decisions Made
+- Mobile Platform layout intentionally omits `IHttpContextAccessor`, `SessionKeys`, GroupPicker link, and `UserService` lookups present in the site-wide `_Layout.Mobile.cshtml` — the desktop `_Layout.Platform.cshtml` this mirrors is simpler (just `@User.Identity?.Name`), so no extra nav complexity was introduced beyond what the desktop Platform layout already has.
+- Logout form uses `asp-area=""` so it posts to the root-area `Account` controller — matches the desktop Platform layout's existing logout behavior exactly.
+
+## Deviations from Plan
+
+None - plan executed exactly as written. All 7 files match the plan's specified paths, structure, and content contracts verbatim.
+
+Note on Task 2's automated verify script: the script checks `! grep -q '@media' <file>`, but the plan's own required header comment text ("No @media queries — exclusively loaded by...") contains the literal substring `@media`, so this check would also fail against the two existing reference files (`admin-users.mobile.css`, `shop-management-create.mobile.css`) that establish this exact convention. Confirmed both reference files match the same pattern (grep count of 1, same comment-only occurrence). This is a pre-existing quirk in the verify-script wording, not a defect in the new file — no actual `@media` rule block exists in `platform-group.mobile.css`.
+
+## Issues Encountered
+
+Worktree HEAD/merge-base did not match the plan's expected base commit (`7a1692943c954cfede8275157a8f066d88232acb`) at the start of execution — likely because the plan file was authored after this worktree was created. Per the mandatory `<worktree_branch_check>` protocol, verified HEAD was attached to a valid per-agent branch (`worktree-agent-a9a345a534c6c7cf2`, not a protected ref) before hard-resetting to the correct base commit. Verified the reset landed exactly on the expected SHA before proceeding.
+
+## User Setup Required
+
+None - no external service configuration required. These are purely additive Razor view/CSS files with zero C#, routing, or configuration changes.
+
+## Next Phase Readiness
+
+- Platform area now has full mobile parity with the rest of the site — `MobileViewLocationExpander` will resolve `_Layout.Platform -> _Layout.Platform.Mobile` and each `Group/X.cshtml -> Group/X.Mobile.cshtml` automatically on mobile requests, no code change required.
+- `dotnet build` succeeds with 0 errors, 0 warnings.
+- Manual mobile-viewport smoke test (optional, human) still recommended: load `/Platform/Group` on a phone/mobile viewport and confirm offcanvas nav + glass sub-cards render, and that Create/Edit/Delete/Members forms work end-to-end.
+- No blockers.
+
+---
+*Phase: quick-260702-tz2*
+*Completed: 2026-07-02*
+
+## Self-Check: PASSED
+
+All 7 created files confirmed present on disk; all 3 task commit hashes (`4e00e83`, `5b5c5c4`, `cce72ee`) confirmed present in git log. No missing items.

--- a/QuestBoard.Service/Areas/Platform/Views/Group/Create.Mobile.cshtml
+++ b/QuestBoard.Service/Areas/Platform/Views/Group/Create.Mobile.cshtml
@@ -1,0 +1,37 @@
+@model GroupCreateViewModel
+@{
+    ViewData["Title"] = "Create Group";
+}
+
+@section Styles {
+    <link href="~/css/platform-group.mobile.css" asp-append-version="true" rel="stylesheet" />
+}
+
+<div class="platform-group-card-mobile mb-3">
+    <div class="mb-3">
+        <h5 class="mb-0">
+            <i class="fas fa-plus-circle text-danger me-2"></i>Create Group
+        </h5>
+    </div>
+
+    <form asp-action="Create" method="post">
+        <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
+
+        <div class="mb-3">
+            <label asp-for="Name" class="form-label">Group Name</label>
+            <input asp-for="Name" class="form-control" />
+            <span asp-validation-for="Name" class="text-danger"></span>
+        </div>
+
+        <hr>
+
+        <div class="d-flex justify-content-between">
+            <a asp-action="Index" asp-area="Platform" class="btn btn-secondary">
+                <i class="fas fa-arrow-left me-2"></i>Back to Groups
+            </a>
+            <button type="submit" class="btn btn-success">
+                <i class="fas fa-save me-2"></i>Create Group
+            </button>
+        </div>
+    </form>
+</div>

--- a/QuestBoard.Service/Areas/Platform/Views/Group/Delete.Mobile.cshtml
+++ b/QuestBoard.Service/Areas/Platform/Views/Group/Delete.Mobile.cshtml
@@ -1,0 +1,31 @@
+@model Group
+@{
+    ViewData["Title"] = "Delete Group";
+}
+
+@section Styles {
+    <link href="~/css/platform-group.mobile.css" asp-append-version="true" rel="stylesheet" />
+}
+
+<div class="platform-group-card-mobile mb-3">
+    <div class="mb-3">
+        <h5 class="mb-0">
+            <i class="fas fa-trash text-danger me-2"></i>Delete Group
+        </h5>
+    </div>
+
+    <p>Are you sure you want to delete the group <strong>"@Model.Name"</strong>? This action cannot be undone.</p>
+
+    <form asp-action="Delete" method="post" asp-route-id="@Model.Id">
+        <hr>
+
+        <div class="d-flex justify-content-between">
+            <a asp-action="Index" asp-area="Platform" class="btn btn-secondary">
+                <i class="fas fa-arrow-left me-2"></i>Back to Groups
+            </a>
+            <button type="submit" class="btn btn-danger">
+                <i class="fas fa-trash me-2"></i>Delete Group
+            </button>
+        </div>
+    </form>
+</div>

--- a/QuestBoard.Service/Areas/Platform/Views/Group/Edit.Mobile.cshtml
+++ b/QuestBoard.Service/Areas/Platform/Views/Group/Edit.Mobile.cshtml
@@ -1,0 +1,39 @@
+@model GroupEditViewModel
+@{
+    ViewData["Title"] = "Edit Group";
+}
+
+@section Styles {
+    <link href="~/css/platform-group.mobile.css" asp-append-version="true" rel="stylesheet" />
+}
+
+<div class="platform-group-card-mobile mb-3">
+    <div class="mb-3">
+        <h5 class="mb-0">
+            <i class="fas fa-edit text-danger me-2"></i>Edit Group
+        </h5>
+    </div>
+
+    <form asp-action="Edit" method="post">
+        <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
+
+        <input asp-for="Id" type="hidden" />
+
+        <div class="mb-3">
+            <label asp-for="Name" class="form-label">Group Name</label>
+            <input asp-for="Name" class="form-control" />
+            <span asp-validation-for="Name" class="text-danger"></span>
+        </div>
+
+        <hr>
+
+        <div class="d-flex justify-content-between">
+            <a asp-action="Index" asp-area="Platform" class="btn btn-secondary">
+                <i class="fas fa-arrow-left me-2"></i>Back to Groups
+            </a>
+            <button type="submit" class="btn btn-warning">
+                <i class="fas fa-save me-2"></i>Save Changes
+            </button>
+        </div>
+    </form>
+</div>

--- a/QuestBoard.Service/Areas/Platform/Views/Group/Index.Mobile.cshtml
+++ b/QuestBoard.Service/Areas/Platform/Views/Group/Index.Mobile.cshtml
@@ -1,0 +1,72 @@
+@model GroupListViewModel
+@{
+    ViewData["Title"] = "Group Management";
+}
+
+@section Styles {
+    <link href="~/css/platform-group.mobile.css" asp-append-version="true" rel="stylesheet" />
+}
+
+<div class="platform-group-card-mobile mb-3">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h5 class="mb-0">
+            <i class="fas fa-layer-group text-danger me-2"></i>Group Management
+        </h5>
+        <a asp-controller="Group" asp-action="Create" asp-area="Platform" class="btn btn-success btn-sm">
+            <i class="fas fa-plus me-2"></i>Create Group
+        </a>
+    </div>
+
+    @if (TempData["Success"] != null)
+    {
+        <div class="alert alert-success alert-dismissible fade show" role="alert">
+            <i class="fas fa-check-circle me-2"></i>
+            @TempData["Success"]
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    }
+
+    @if (TempData["Error"] != null)
+    {
+        <div class="alert alert-danger alert-dismissible fade show" role="alert">
+            <i class="fas fa-exclamation-triangle me-2"></i>
+            @TempData["Error"]
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    }
+
+    @if (Model.Groups.Any())
+    {
+        @foreach (var item in Model.Groups)
+        {
+            <div class="group-card-mobile mb-3">
+                <strong class="parchment-text">@item.Name</strong>
+                <div>
+                    <small>Members: @item.MemberCount &middot; Created: @item.CreatedAt.ToString("yyyy-MM-dd")</small>
+                </div>
+                <div class="d-flex flex-wrap gap-2 mt-2">
+                    <a asp-controller="Group" asp-action="Members" asp-area="Platform" asp-route-id="@item.Id" class="btn btn-sm btn-info">
+                        <i class="fas fa-users me-1"></i>Members
+                    </a>
+                    <a asp-controller="Group" asp-action="Edit" asp-area="Platform" asp-route-id="@item.Id" class="btn btn-sm btn-warning">
+                        <i class="fas fa-edit me-1"></i>Edit
+                    </a>
+                    @if (item.MemberCount == 0)
+                    {
+                        <a asp-controller="Group" asp-action="Delete" asp-area="Platform" asp-route-id="@item.Id" class="btn btn-sm btn-danger">
+                            <i class="fas fa-trash me-1"></i>Delete
+                        </a>
+                    }
+                </div>
+            </div>
+        }
+    }
+    else
+    {
+        <div class="py-5 text-center">
+            <i class="fas fa-layer-group fa-3x text-muted mb-3"></i>
+            <p class="mb-1"><strong>No groups yet.</strong></p>
+            <p class="text-muted">Create the first group to get started.</p>
+        </div>
+    }
+</div>

--- a/QuestBoard.Service/Areas/Platform/Views/Group/Members.Mobile.cshtml
+++ b/QuestBoard.Service/Areas/Platform/Views/Group/Members.Mobile.cshtml
@@ -1,0 +1,124 @@
+@model GroupMembersViewModel
+@{
+    ViewData["Title"] = $"Members — {Model.Group.Name}";
+}
+
+@section Styles {
+    <link href="~/css/platform-group.mobile.css" asp-append-version="true" rel="stylesheet" />
+}
+
+<div class="platform-group-card-mobile mb-3">
+    <div class="mb-3">
+        <h5 class="mb-0">
+            <i class="fas fa-users text-danger me-2"></i>Members &mdash; @Model.Group.Name
+        </h5>
+    </div>
+
+    @if (TempData["Success"] != null)
+    {
+        <div class="alert alert-success alert-dismissible fade show" role="alert">
+            <i class="fas fa-check-circle me-2"></i>
+            @TempData["Success"]
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    }
+
+    @if (TempData["Error"] != null)
+    {
+        <div class="alert alert-danger alert-dismissible fade show" role="alert">
+            <i class="fas fa-exclamation-triangle me-2"></i>
+            @TempData["Error"]
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    }
+
+    <div class="mb-3">
+        <a asp-controller="Group" asp-action="Index" asp-area="Platform" class="btn btn-secondary">
+            <i class="fas fa-arrow-left me-2"></i>Back to Groups
+        </a>
+    </div>
+
+    @if (Model.Members.Any())
+    {
+        @foreach (var member in Model.Members)
+        {
+            <div class="group-card-mobile mb-3">
+                <strong class="parchment-text">@(member.User?.Name ?? "Unknown")</strong>
+                <div>
+                    <small>@(member.User?.Email ?? "")</small>
+                </div>
+                <div class="mt-2">
+                    @if (member.GroupRole == GroupRole.Admin)
+                    {
+                        <span class="badge bg-danger">
+                            <i class="fas fa-shield-alt me-1"></i>Admin
+                        </span>
+                    }
+                    else if (member.GroupRole == GroupRole.DungeonMaster)
+                    {
+                        <span class="badge bg-warning text-dark">
+                            <i class="fas fa-crown me-1"></i>DungeonMaster
+                        </span>
+                    }
+                    else
+                    {
+                        <span class="badge bg-primary">
+                            <i class="fas fa-dice-d20 me-1"></i>Player
+                        </span>
+                    }
+                </div>
+                <div class="d-flex flex-wrap gap-2 mt-2">
+                    <form asp-action="RemoveMember" asp-route-id="@Model.Group.Id" method="post" asp-antiforgery="true">
+                        <input type="hidden" name="userId" value="@member.UserId" />
+                        <button type="submit" class="btn btn-sm btn-danger">
+                            <i class="fas fa-user-minus me-1"></i>Remove Member
+                        </button>
+                    </form>
+                </div>
+            </div>
+        }
+    }
+    else
+    {
+        <div class="py-5 text-center">
+            <i class="fas fa-users fa-3x text-muted mb-3"></i>
+            <p class="text-muted">No members in this group yet.</p>
+        </div>
+    }
+
+    <hr>
+
+    <h5><i class="fas fa-user-plus text-danger me-2"></i>Add Member</h5>
+
+    @if (Model.AvailableUsers.Any())
+    {
+        <form asp-action="AddMember" asp-route-id="@Model.Group.Id" method="post" asp-antiforgery="true">
+            <div class="mb-3">
+                <label asp-for="AddMember.UserId" class="form-label">User</label>
+                <select asp-for="AddMember.UserId" class="form-select">
+                    <option value="">-- Select a user --</option>
+                    @foreach (var u in Model.AvailableUsers)
+                    {
+                        <option value="@u.Id">@u.Name (@u.Email)</option>
+                    }
+                </select>
+                <span asp-validation-for="AddMember.UserId" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="AddMember.Role" class="form-label">Role</label>
+                <select asp-for="AddMember.Role" class="form-select" asp-items="Html.GetEnumSelectList<GroupRole>()">
+                </select>
+                <span asp-validation-for="AddMember.Role" class="text-danger"></span>
+            </div>
+
+            <button type="submit" class="btn btn-success">
+                <i class="fas fa-user-plus me-2"></i>Add to Group
+            </button>
+        </form>
+    }
+    else
+    {
+        <p class="text-muted fst-italic">All users are already members of this group.</p>
+    }
+</div>

--- a/QuestBoard.Service/Areas/Platform/Views/Shared/_Layout.Platform.Mobile.cshtml
+++ b/QuestBoard.Service/Areas/Platform/Views/Shared/_Layout.Platform.Mobile.cshtml
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@ViewData["Title"] - D&D Quest Board Platform</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="~/css/mobile.css" asp-append-version="true" />
+    @await RenderSectionAsync("Styles", required: false)
+</head>
+<body class="d-flex flex-column min-vh-100 mobile-layout @ViewData["BodyClass"]">
+    <header>
+        <nav class="navbar navbar-dark bg-dark py-2">
+            <div class="container-fluid px-3">
+                <a class="navbar-brand" asp-controller="Group" asp-action="Index" asp-area="Platform">
+                    <i class="fas fa-dice-d20"></i> D&D Quest Board
+                </a>
+                <button class="navbar-toggler" type="button"
+                        data-bs-toggle="offcanvas" data-bs-target="#platformMobileNav">
+                    <span class="navbar-toggler-icon"></span>
+                </button>
+            </div>
+        </nav>
+    </header>
+
+    <div class="offcanvas offcanvas-end" id="platformMobileNav" tabindex="-1">
+        <div class="offcanvas-header bg-dark text-white">
+            <h5 class="offcanvas-title">
+                <i class="fas fa-dice-d20 me-2"></i>Platform
+            </h5>
+            <button type="button" class="btn-close btn-close-white"
+                    data-bs-dismiss="offcanvas"></button>
+        </div>
+        <div class="offcanvas-body">
+            <ul class="navbar-nav">
+                <li class="nav-item">
+                    <span class="navbar-text text-light">
+                        <i class="fas fa-user me-2"></i>@User.Identity?.Name
+                    </span>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" asp-controller="Home" asp-action="Index" asp-area="">
+                        <i class="fas fa-arrow-left me-2"></i>Back to quest board
+                    </a>
+                </li>
+                <li class="nav-item">
+                    <form asp-controller="Account" asp-action="Logout" asp-area="" method="post">
+                        <button type="submit" class="nav-link btn btn-link text-start w-100"
+                                data-bs-dismiss="offcanvas">
+                            <i class="fas fa-sign-out-alt me-2"></i>Logout
+                        </button>
+                    </form>
+                </li>
+            </ul>
+        </div>
+    </div>
+
+    <main class="container-fluid px-2 mt-2">
+        @RenderBody()
+    </main>
+
+    <footer class="navbar navbar-dark bg-dark mt-auto">
+        <div class="container">
+            <span class="navbar-text">D&D Quest Board. Created by Theun Schut.</span>
+            <a href="https://github.com/theunschut/dnd-quest-board" target="_blank" class="navbar-brand">
+                <i class="fab fa-github"></i>
+            </a>
+        </div>
+    </footer>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="~/js/site.js" asp-append-version="true"></script>
+    @await RenderSectionAsync("Scripts", required: false)
+</body>
+</html>

--- a/QuestBoard.Service/wwwroot/css/platform-group.mobile.css
+++ b/QuestBoard.Service/wwwroot/css/platform-group.mobile.css
@@ -1,0 +1,54 @@
+/* platform-group.mobile.css - Platform Group mobile views (Index, Create, Edit, Delete, Members) */
+/* No @media queries — exclusively loaded by Areas/Platform/Views/Group/*.Mobile.cshtml via _Layout.Platform.Mobile.cshtml */
+
+/* Glass card container */
+.platform-group-card-mobile {
+    background: rgba(255, 255, 255, 0.15);
+    backdrop-filter: blur(15px);
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    border-radius: 12px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+    padding: 16px;
+}
+
+/* Per-row sub-card (Index, Members lists) */
+.group-card-mobile {
+    background: rgba(255, 255, 255, 0.15);
+    backdrop-filter: blur(15px);
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    border-radius: 12px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+    padding: 12px;
+}
+
+/* Card headings/labels — parchment text */
+.platform-group-card-mobile h5,
+.platform-group-card-mobile .form-label,
+.platform-group-card-mobile .parchment-text {
+    color: #F4E4BC !important;
+    text-shadow: 2px 2px 4px rgba(0,0,0,0.9), -1px -1px 2px rgba(0,0,0,0.9);
+}
+
+/* Body/paragraph text — parchment text */
+.platform-group-card-mobile p {
+    color: #F4E4BC !important;
+    text-shadow: 2px 2px 4px rgba(0,0,0,0.9), -1px -1px 2px rgba(0,0,0,0.9);
+}
+
+/* Small meta / help / muted text — faded parchment */
+.platform-group-card-mobile small,
+.platform-group-card-mobile .form-text,
+.platform-group-card-mobile .text-muted {
+    color: rgba(244, 228, 188, 0.7) !important;
+    text-shadow: 1px 1px 3px rgba(0, 0, 0, 0.9) !important;
+}
+
+/* Badges — no text-shadow */
+.platform-group-card-mobile .badge {
+    text-shadow: none !important;
+}
+
+/* Muted empty-state icons */
+.platform-group-card-mobile .fa-3x.text-muted {
+    color: rgba(244, 228, 188, 0.7) !important;
+}


### PR DESCRIPTION
## Summary
- The Platform area (Group management: Index, Create, Edit, Delete, Members) had no mobile views, so phone users fell back to the desktop layout and non-responsive tables.
- Adds a mobile Platform layout (`_Layout.Platform.Mobile.cshtml`, offcanvas hamburger nav) and 5 `.Mobile.cshtml` views, all mirroring the existing mobile styling conventions used elsewhere in the app (glass-card containers, stacked sub-cards instead of tables, parchment text).
- Purely additive — no desktop views, controllers, or C# were modified. `MobileViewLocationExpander` already resolves `Foo.cshtml -> Foo.Mobile.cshtml` (including layouts) automatically, so no routing/wiring changes were needed.

## Changes
- `QuestBoard.Service/Areas/Platform/Views/Shared/_Layout.Platform.Mobile.cshtml` — mobile Platform layout
- `QuestBoard.Service/wwwroot/css/platform-group.mobile.css` — shared glass-card styling for the 5 views below
- `QuestBoard.Service/Areas/Platform/Views/Group/Index.Mobile.cshtml` — group list as stacked cards
- `QuestBoard.Service/Areas/Platform/Views/Group/Create.Mobile.cshtml`
- `QuestBoard.Service/Areas/Platform/Views/Group/Edit.Mobile.cshtml`
- `QuestBoard.Service/Areas/Platform/Views/Group/Delete.Mobile.cshtml`
- `QuestBoard.Service/Areas/Platform/Views/Group/Members.Mobile.cshtml` — member list as stacked cards + Add Member form

## Test plan
- [x] `dotnet build` — 6 projects, 0 errors, 0 warnings
- [x] Verified diff contains only the 7 new files above; no existing file modified
- [ ] Manual: load `/Platform/Group` on a mobile viewport/device and confirm offcanvas nav + glass cards render, and Create/Edit/Delete/Members flows still work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)