### PR TITLE
Show app version in footer, stamped by CI from the release tag

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -25,8 +25,12 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      - name: Determine version
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
       - name: Publish
-        run: dotnet publish QuestBoard.Service/QuestBoard.Service.csproj -c Release -o ./publish
+        run: dotnet publish QuestBoard.Service/QuestBoard.Service.csproj -c Release -o ./publish -p:Version=${{ steps.version.outputs.version }}
 
       - name: Zip artifact
         run: cd publish && zip -r ../questboard-${{ github.ref_name }}.zip .

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -66,6 +66,10 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
+      - name: Determine version
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
@@ -82,6 +86,7 @@ jobs:
           # Enable BuildKit cache mount for NuGet packages
           build-args: |
             BUILDKIT_INLINE_CACHE=1
+            VERSION=${{ steps.version.outputs.version }}
 
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ EXPOSE 8080
 
 # Use the SDK image to build the app
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+ARG VERSION=0.0.0-dev
 WORKDIR /src
 
 # Copy only production project files (exclude test projects)
@@ -23,11 +24,12 @@ COPY ["QuestBoard.Service/", "QuestBoard.Service/"]
 
 # Build only the Service project (which transitively builds Domain and Repository)
 RUN --mount=type=cache,target=/root/.nuget/packages \
-    dotnet build "QuestBoard.Service/QuestBoard.Service.csproj" -c Release --no-restore
+    dotnet build "QuestBoard.Service/QuestBoard.Service.csproj" -c Release --no-restore -p:Version=$VERSION
 
 FROM build AS publish
+ARG VERSION=0.0.0-dev
 RUN --mount=type=cache,target=/root/.nuget/packages \
-    dotnet publish "QuestBoard.Service/QuestBoard.Service.csproj" -c Release -o /app/publish --no-build
+    dotnet publish "QuestBoard.Service/QuestBoard.Service.csproj" -c Release -o /app/publish --no-build -p:Version=$VERSION
 
 # Build runtime image
 FROM base AS final

--- a/QuestBoard.Service/Areas/Platform/Views/Shared/_Layout.Platform.Mobile.cshtml
+++ b/QuestBoard.Service/Areas/Platform/Views/Shared/_Layout.Platform.Mobile.cshtml
@@ -62,14 +62,7 @@
     </main>
     <partial name="_Toasts" />
 
-    <footer class="navbar navbar-dark bg-dark mt-auto">
-        <div class="container">
-            <span class="navbar-text">D&D Quest Board. Created by Theun Schut.</span>
-            <a href="https://github.com/theunschut/dnd-quest-board" target="_blank" class="navbar-brand">
-                <i class="fab fa-github"></i>
-            </a>
-        </div>
-    </footer>
+    <partial name="_Footer" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>

--- a/QuestBoard.Service/Helpers/AppVersion.cs
+++ b/QuestBoard.Service/Helpers/AppVersion.cs
@@ -1,0 +1,17 @@
+using System.Reflection;
+
+namespace QuestBoard.Service.Helpers;
+
+public static class AppVersion
+{
+    public static string Current { get; } = ExtractVersion(
+        Assembly.GetEntryAssembly()
+            ?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion);
+
+    public static string ExtractVersion(string? informationalVersion)
+    {
+        // Strip the +<git-sha> metadata suffix the SDK appends automatically.
+        return informationalVersion?.Split('+')[0] ?? "dev";
+    }
+}

--- a/QuestBoard.Service/QuestBoard.Service.csproj
+++ b/QuestBoard.Service/QuestBoard.Service.csproj
@@ -4,6 +4,7 @@
 		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
+		<Version>0.0.0-dev</Version>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/QuestBoard.Service/Views/Shared/_Footer.cshtml
+++ b/QuestBoard.Service/Views/Shared/_Footer.cshtml
@@ -1,0 +1,9 @@
+@using QuestBoard.Service.Helpers
+<footer class="navbar navbar-dark bg-dark mt-auto">
+    <div class="container">
+        <span class="navbar-text">D&amp;D Quest Board v@(AppVersion.Current). Created by Theun Schut.</span>
+        <a href="https://github.com/theunschut/dnd-quest-board" target="_blank" class="navbar-brand">
+            <i class="fab fa-github"></i>
+        </a>
+    </div>
+</footer>

--- a/QuestBoard.Service/Views/Shared/_Layout.Mobile.cshtml
+++ b/QuestBoard.Service/Views/Shared/_Layout.Mobile.cshtml
@@ -175,14 +175,7 @@
     </main>
     <partial name="_Toasts" />
 
-    <footer class="navbar navbar-dark bg-dark mt-auto">
-        <div class="container">
-            <span class="navbar-text">D&D Quest Board. Created by Theun Schut.</span>
-            <a href="https://github.com/theunschut/dnd-quest-board" target="_blank" class="navbar-brand">
-                <i class="fab fa-github"></i>
-            </a>
-        </div>
-    </footer>
+    <partial name="_Footer" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>

--- a/QuestBoard.Service/Views/Shared/_Layout.cshtml
+++ b/QuestBoard.Service/Views/Shared/_Layout.cshtml
@@ -207,14 +207,7 @@
     </div>
     <partial name="_Toasts" />
 
-    <footer class="navbar navbar-dark bg-dark mt-auto">
-        <div class="container">
-            <span class="navbar-text">D&D Quest Board. Created by Theun Schut.</span>
-            <a href="https://github.com/theunschut/dnd-quest-board" target="_blank" class="navbar-brand">
-                <i class="fab fa-github"></i>
-            </a>
-        </div>
-    </footer>
+    <partial name="_Footer" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>

--- a/QuestBoard.UnitTests/Helpers/AppVersionTests.cs
+++ b/QuestBoard.UnitTests/Helpers/AppVersionTests.cs
@@ -1,0 +1,24 @@
+using QuestBoard.Service.Helpers;
+
+namespace QuestBoard.UnitTests.Helpers;
+
+public class AppVersionTests
+{
+    [Fact]
+    public void ExtractVersion_NullInformationalVersion_ReturnsDev()
+    {
+        AppVersion.ExtractVersion(null).Should().Be("dev");
+    }
+
+    [Fact]
+    public void ExtractVersion_PlainSemver_ReturnsUnchanged()
+    {
+        AppVersion.ExtractVersion("1.4.2").Should().Be("1.4.2");
+    }
+
+    [Fact]
+    public void ExtractVersion_WithSourceRevisionSuffix_StripsSuffix()
+    {
+        AppVersion.ExtractVersion("1.4.2+a1b2c3d4e5f6").Should().Be("1.4.2");
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a shared `_Footer.cshtml` partial (replacing 3 duplicated footer blocks) that displays the app version, e.g. `D&D Quest Board v1.4.2. Created by Theun Schut.`
- New `AppVersion` helper reads the version from the assembly's informational-version attribute, stripping the `+<git-sha>` suffix the SDK appends automatically, and falls back to `0.0.0-dev` for local builds
- `binary-release.yml` and `docker-publish.yml` (+ `Dockerfile`) now strip the leading `v` from the pushed release tag and pass it through as `-p:Version=` at build time, so the deployed binary/image is stamped with the real release version — no manual version bumping anywhere in source
- Adds unit tests for the version-parsing/fallback logic (the assembly-reading part isn't meaningfully unit-testable since `Assembly.GetEntryAssembly()` returns the test host in a test run, not `QuestBoard.Service`)

## Test plan
- [x] `dotnet build` with no `-p:Version` → footer shows `v0.0.0-dev` (verified in VS)
- [x] Simulated CI build (`dotnet build -p:Version=1.4.2`) → footer shows `v1.4.2` (verified via direct curl against the built binary)
- [x] `dotnet test` — 3/3 new `AppVersionTests` pass
- [ ] Real tag push through `binary-release.yml`/`docker-publish.yml` — not exercised in this PR (reviewed by inspection only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)