### PR TITLE
docs: clarify remaining userId-not-PII CodeQL comments

### DIFF
--- a/QuestBoard.Service/Areas/Platform/Controllers/GroupController.cs
+++ b/QuestBoard.Service/Areas/Platform/Controllers/GroupController.cs
@@ -175,6 +175,8 @@ public class GroupController(
                     // Existing user added to a group they weren't in — notify them by email.
                     var loginUrl = Url.Action("Login", "Account", null, Request.Scheme);
                     if (loginUrl == null)
+                        // userId is a database-internal integer identifier, not personal data — despite
+                        // flowing from the newly created account, it carries no PII of its own.
                         logger.LogError("Failed to generate Login callback URL for userId {UserId}", result.UserId);
                     else
                         jobClient.Enqueue<GroupMembershipAddedEmailJob>(j => j.ExecuteAsync(result.Email, result.Name, group.Name, model.Role.ToString(), loginUrl, CancellationToken.None));
@@ -192,6 +194,8 @@ public class GroupController(
                         var encodedToken = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(rawToken));
                         var callbackUrl = Url.Action("SetPassword", "Account", new { userId = result.UserId.Value, token = encodedToken }, Request.Scheme);
                         if (callbackUrl == null)
+                            // userId is a database-internal integer identifier, not personal data — despite
+                            // flowing from the newly created account, it carries no PII of its own.
                             logger.LogError("Failed to generate SetPassword callback URL for userId {UserId}", result.UserId.Value);
                         else
                         {
@@ -266,6 +270,8 @@ public class GroupController(
                 {
                     var loginUrl = Url.Action("Login", "Account", null, Request.Scheme);
                     if (loginUrl == null)
+                        // userId is a database-internal integer identifier, not personal data — despite
+                        // flowing from the newly created account, it carries no PII of its own.
                         logger.LogError("Failed to generate Login callback URL for userId {UserId}", result.UserId);
                     else
                         jobClient.Enqueue<GroupMembershipAddedEmailJob>(j => j.ExecuteAsync(result.Email, result.Name, group.Name, model.GroupRole.ToString(), loginUrl, CancellationToken.None));
@@ -282,6 +288,8 @@ public class GroupController(
                         var encodedToken = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(rawToken));
                         var callbackUrl = Url.Action("SetPassword", "Account", new { userId = result.UserId.Value, token = encodedToken }, Request.Scheme);
                         if (callbackUrl == null)
+                            // userId is a database-internal integer identifier, not personal data — despite
+                            // flowing from the newly created account, it carries no PII of its own.
                             logger.LogError("Failed to generate SetPassword callback URL for userId {UserId}", result.UserId.Value);
                         else
                         {


### PR DESCRIPTION
## Summary
Follow-up to #129 — CodeQL alerts #40/#41 were freshly flagged after that PR merged into main, in two `GroupController.AddMember` call sites I'd missed. Same false-positive class already established and dismissed on #34-#37: `result.UserId` is a plain database integer identifier, not personal data, despite being a field on the same result object that also carries an email address (which is what makes CodeQL's taint tracker flag the whole object).

Added the same clarifying comment to all remaining call sites for consistency (5 total in `GroupController.cs` now documented).

## Test plan
- [x] `dotnet build` succeeds
- [x] `GroupManagementIntegrationTests` (32 tests) pass — comment-only change, no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)