### PR TITLE
Add re-crop trigger for existing profile images

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -31,7 +31,7 @@ See: .planning/PROJECT.md (updated 2026-07-11 — v8.0 milestone close)
 Phase: None (between milestones)
 Plan: None
 Status: v8.0 shipped; no active milestone
-Last activity: 2026-07-11 — v8.0 milestone archived
+Last activity: 2026-07-13 - Completed quick task 260713-js8: Add re-crop trigger for existing profile images (Characters, Contacts, DM Profile) and fix backend gaps that would drop or wipe crop-only submissions
 
 Progress: [██████████] 100% (v8.0, 7/7 phases)
 
@@ -68,6 +68,12 @@ None open for v8.0. Carried forward from prior milestones, still unresolved:
 - `GroupSessionMiddleware` redirects on all HTTP verbs including POST — a POST-body data-loss risk if the session expires mid-submission; flagged by code review during Phase 31, not yet fixed.
 - `Areas/Platform/Views/Shared/_Layout.Platform.Mobile.cshtml` appears to be dead code (Platform area's `_ViewStart.cshtml` never selects it) — discovered during Phase 42 research, deliberately left unfixed as out-of-scope for that phase. See PROJECT.md Known Issues.
 - `GuildMembersController.Edit` POST's `SetAsMainCharacterAsync` demotion guard can never be true (dead code, predates Phase 56) — found during Phase 56 verification, flagged as a separate follow-up task, not yet actioned. See PROJECT.md Known Issues.
+
+### Quick Tasks Completed
+
+| # | Description | Date | Commit | Directory |
+|---|-------------|------|--------|-----------|
+| 260713-js8 | Add re-crop trigger for existing profile images (Characters, Contacts, DM Profile) and fix backend gaps that would drop or wipe crop-only submissions | 2026-07-13 | d2f2f95 | [260713-js8-add-re-crop-trigger-for-existing-profile](./quick/260713-js8-add-re-crop-trigger-for-existing-profile/) |
 
 ## Deferred Items
 

--- a/.planning/quick/260713-js8-add-re-crop-trigger-for-existing-profile/260713-js8-01-SUMMARY.md
+++ b/.planning/quick/260713-js8-add-re-crop-trigger-for-existing-profile/260713-js8-01-SUMMARY.md
@@ -1,0 +1,171 @@
+---
+phase: 260713-js8-add-re-crop-trigger-for-existing-profile
+plan: 01
+subsystem: ui
+tags: [image-upload, cropperjs, aspnet-core-mvc, ef-core]
+
+requires: []
+provides:
+  - Re-crop Photo trigger on all 3 profile-image Edit flows (Character, Contact, DM Profile), reusing the shared crop modal against the stored ORIGINAL image
+  - GetOriginalDMProfilePicture endpoint exposing the DM's original (uncropped) image
+  - Crop-only save support across DungeonMasterProfileService, CharactersController, and ContactsController (previously silently dropped or, for DM Profile, would have wiped the stored photo)
+affects: [dungeon-master-profile, characters, contacts, image-crop-js]
+
+tech-stack:
+  added: []
+  patterns:
+    - "Client-side re-crop trigger fetches the stored original via fetch()+blob, sniffs Content-Type for animated GIF, and reuses the same crop-modal-open path as a fresh file-input selection (openCropperWithPreparedBlob)"
+    - "Crop-only service-layer edits re-fetch the existing stored original before writing, so a null original round-trip is never mistaken for delete-the-image"
+
+key-files:
+  created: []
+  modified:
+    - QuestBoard.Domain/Services/DungeonMasterProfileService.cs
+    - QuestBoard.Service/Controllers/DungeonMaster/DungeonMasterController.cs
+    - QuestBoard.Service/Controllers/Characters/CharactersController.cs
+    - QuestBoard.Service/Controllers/Contacts/ContactsController.cs
+    - QuestBoard.Service/wwwroot/js/image-crop.js
+    - QuestBoard.Service/Views/Characters/Edit.cshtml
+    - QuestBoard.Service/Views/Characters/Edit.Mobile.cshtml
+    - QuestBoard.Service/Views/Contacts/Edit.cshtml
+    - QuestBoard.Service/Views/Contacts/Edit.Mobile.cshtml
+    - QuestBoard.Service/Views/DungeonMaster/EditProfile.cshtml
+    - QuestBoard.Service/Views/DungeonMaster/EditProfile.Mobile.cshtml
+    - QuestBoard.UnitTests/Services/DungeonMasterProfileServiceTests.cs
+    - QuestBoard.UnitTests/Services/CharacterServiceTests.cs
+    - QuestBoard.UnitTests/Services/ContactServiceTests.cs
+    - QuestBoard.IntegrationTests/Controllers/CharactersControllerIntegrationTests.cs
+    - QuestBoard.IntegrationTests/Controllers/ContactsControllerIntegrationTests.cs
+    - QuestBoard.IntegrationTests/Controllers/DungeonMasterControllerIntegrationTests.cs
+
+key-decisions:
+  - "Re-crop fetches the stored ORIGINAL image (not the cropped preview) so a bad first crop can be corrected without permanently losing the cut-off parts of the photo"
+  - "GIF originals refuse to open the re-crop modal (Content-Type sniffed at fetch time) rather than silently collapsing an animated GIF to a static cropped JPEG"
+  - "DungeonMasterProfileService re-fetches the existing original on a crop-only edit rather than trusting a null passthrough, since the repository interprets a null original as delete-the-image"
+
+requirements-completed: [js8-recrop]
+
+coverage:
+  - id: D1
+    description: "DM Profile crop-only save persists the new crop and preserves the stored original (critical no-wipe fix)"
+    requirement: js8-recrop
+    verification:
+      - kind: unit
+        ref: "QuestBoard.UnitTests/Services/DungeonMasterProfileServiceTests.cs#UpsertProfileAsync_CropOnlyNoNewOriginal_PersistsCropAndPreservesOriginal"
+        status: pass
+      - kind: integration
+        ref: "QuestBoard.IntegrationTests/Controllers/DungeonMasterControllerIntegrationTests.cs#EditProfile_CropOnlyNoNewOriginal_PreservesStoredOriginal"
+        status: pass
+    human_judgment: false
+  - id: D2
+    description: "Character and Contact crop-only saves persist the submitted crop and preserve the stored original"
+    requirement: js8-recrop
+    verification:
+      - kind: unit
+        ref: "QuestBoard.UnitTests/Services/CharacterServiceTests.cs#UpdateAsync_CropOnlyNoNewOriginal_PersistsCropAndPreservesOriginal"
+        status: pass
+      - kind: unit
+        ref: "QuestBoard.UnitTests/Services/ContactServiceTests.cs#UpdateAsync_CropOnlyNoNewOriginal_PersistsCropAndPreservesOriginal"
+        status: pass
+      - kind: integration
+        ref: "QuestBoard.IntegrationTests/Controllers/CharactersControllerIntegrationTests.cs#Edit_CropOnlyNoNewOriginal_PersistsCropAndPreservesOriginal"
+        status: pass
+      - kind: integration
+        ref: "QuestBoard.IntegrationTests/Controllers/ContactsControllerIntegrationTests.cs#Edit_CropOnlyNoNewOriginal_PersistsCropAndPreservesOriginal"
+        status: pass
+    human_judgment: false
+  - id: D3
+    description: "Re-crop Photo button present and wired (recropButtonId/originalImageUrl) in all 6 Edit views (Character, Contact, DM Profile desktop+mobile), gated on an existing photo"
+    requirement: js8-recrop
+    verification:
+      - kind: other
+        ref: "grep -rl recropPhotoBtn across the 6 Edit views (verified during execution, 6/6 matched) + dotnet build QuestBoard.Service"
+        status: pass
+    human_judgment: true
+    rationale: "Automated checks confirm the button and script wiring exist and the app compiles, but actually opening the crop modal against the fetched original in a live browser (visual/interactive confirmation) was not exercised in this environment — recommend a manual click-through per the plan's optional manual verification step."
+  - id: D4
+    description: "An animated GIF stored original refuses to open the re-crop modal and shows a message instead of silently flattening to a static crop"
+    verification: []
+    human_judgment: true
+    rationale: "The GIF-refusal branch (Content-Type sniff + showError) was implemented by mirroring the existing upload-path GIF skip, but no automated test exercises a live GIF fetch through the browser; needs a manual click-through to confirm the message displays correctly."
+
+duration: 11min
+completed: 2026-07-13
+status: complete
+---
+
+# Quick Task 260713-js8: Add re-crop trigger for existing profile Summary
+
+**Re-crop Photo button on all 3 profile-image Edit flows, loading the stored original into the shared Cropper.js modal, plus a DM-Profile backend fix that stops a crop-only save from wiping the stored photo**
+
+## Performance
+
+- **Duration:** ~11 min
+- **Started:** 2026-07-13T14:24:53+02:00 (plan committed)
+- **Completed:** 2026-07-13T14:35:32+02:00
+- **Tasks:** 6/6
+- **Files modified:** 17
+
+## Accomplishments
+- Fixed a latent bug where a DM Profile crop-only save would silently no-op (crop discarded) or, once the controller was widened, would have wiped the stored photo entirely — `UpsertProfileAsync` now re-fetches the existing original before writing on a crop-only edit
+- Added `GetOriginalDMProfilePicture`, the missing endpoint exposing the DM's original (uncropped) image, guarded by the same `IsTargetInActiveGroupAsync` check as the existing cropped-image endpoint
+- Restructured `CharactersController.Edit` and `ContactsController.Edit` so a crop-only submission (no new original file) is read, validated, and persisted instead of being silently dropped
+- Extended the shared `image-crop.js` pipeline with a re-crop trigger (`recropButtonId`/`originalImageUrl` config) that fetches the stored original, refuses animated GIFs with a message, and reuses the existing modal/confirm/cancel/hidden-input logic via a new `openCropperWithPreparedBlob` helper
+- Wired the "Re-crop Photo" button into all 6 Edit views (Character, Contact, DM Profile — desktop + mobile), gated on the existing photo-present flag
+- Added unit tests (DM no-wipe, Character, Contact) and integration tests (all 3 controllers) covering the crop-only-without-new-original scenario
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Fix DM Profile crop-only backend** - `41e775a` (fix)
+2. **Task 2: Read crop-only submissions in Character/Contact controllers** - `56d9ea1` (fix)
+3. **Task 3: Add re-crop trigger support to image-crop.js** - `79c26a4` (feat)
+4. **Task 4: Wire Re-crop Photo button into all 6 Edit views** - `ed8acef` (feat)
+5. **Task 5: Unit tests for crop-only service behavior** - `d86a063` (test)
+6. **Task 6: Integration tests for crop-only POST** - `d2f2f95` (test)
+
+**Plan metadata:** committed separately by the orchestrator after this summary
+
+## Files Created/Modified
+- `QuestBoard.Domain/Services/DungeonMasterProfileService.cs` - `UpsertProfileAsync` treats a submitted crop as a write reason and re-fetches the existing original on a crop-only edit
+- `QuestBoard.Service/Controllers/DungeonMaster/DungeonMasterController.cs` - restructured `EditProfile` POST to read/validate/persist `CroppedPictureFile` independent of a new upload; added `GetOriginalDMProfilePicture`
+- `QuestBoard.Service/Controllers/Characters/CharactersController.cs` - `Edit` POST reads the crop regardless of `hasNewOriginalUpload`
+- `QuestBoard.Service/Controllers/Contacts/ContactsController.cs` - same restructure as Characters
+- `QuestBoard.Service/wwwroot/js/image-crop.js` - adds `recropButtonId`/`originalImageUrl` config, extracts `openCropperWithPreparedBlob`, wires the re-crop click handler with GIF refusal
+- `QuestBoard.Service/Views/Characters/Edit.cshtml`, `Edit.Mobile.cshtml` - Re-crop Photo button + `initImageCrop` config pointing at `GetProfilePicture`
+- `QuestBoard.Service/Views/Contacts/Edit.cshtml`, `Edit.Mobile.cshtml` - same, pointing at `GetContactImage`
+- `QuestBoard.Service/Views/DungeonMaster/EditProfile.cshtml`, `EditProfile.Mobile.cshtml` - same, pointing at the new `GetOriginalDMProfilePicture`
+- `QuestBoard.UnitTests/Services/DungeonMasterProfileServiceTests.cs`, `CharacterServiceTests.cs`, `ContactServiceTests.cs` - crop-only-without-new-original tests
+- `QuestBoard.IntegrationTests/Controllers/CharactersControllerIntegrationTests.cs`, `ContactsControllerIntegrationTests.cs`, `DungeonMasterControllerIntegrationTests.cs` - crop-only POST integration tests
+
+## Decisions Made
+- Followed the plan's exact fix for the DM Profile no-wipe bug: compute `originalImageData` as the re-fetched existing original whenever the edit is crop-only (`imageBytes == null && !removeImage && newCroppedImageData != null`), otherwise keep the prior `removeImage ? null : imageBytes` expression
+- Reused `ImageValidationService.ValidateImagePair` unchanged for crop-only validation, since it already tolerates a null `original` argument — no new validation method was needed, confirming the plan's note
+- Named the new original-image field variable `originalFile` (re-crop path) using `Content-Type` from the fetch response rather than trusting a file extension, since the stored bytes have no filename
+
+## Deviations from Plan
+
+None - plan executed exactly as written. All `<action>` guidance in the plan mapped directly to the implementation with no additional fixes needed.
+
+## Issues Encountered
+
+None. The solution builds cleanly after each task, and the full unit test suite (305 tests) and full integration test suite (399 tests, exercising the real SQL Server-backed `WebApplicationFactoryBase`) both pass with no failures after all 6 tasks.
+
+## User Setup Required
+
+None - no external service configuration required. No EF migration was needed (existing Original/Cropped columns only).
+
+## Next Phase Readiness
+
+- All three profile-image Edit flows now expose a working Re-crop trigger; the DM Profile no-wipe bug (the highest-risk item in this task) is fixed and covered by both a unit and an integration test
+- Manual/visual verification (opening the crop modal in a live browser, confirming a re-crop persists via the UI, confirming the GIF-refusal message displays) was not performed in this environment — recommended as an optional follow-up per CLAUDE.md's `run` skill, but not blocking given the automated coverage
+- No known blockers for this task; the fix is isolated to the 3 existing photo-upload flows and does not touch schema or other subsystems
+
+---
+*Phase: 260713-js8-add-re-crop-trigger-for-existing-profile*
+*Completed: 2026-07-13*
+
+## Self-Check: PASSED
+
+All 17 files listed under Files Created/Modified (plus this SUMMARY) verified present on disk, and all 6 task commit hashes (41e775a, 56d9ea1, 79c26a4, ed8acef, d86a063, d2f2f95) verified present in git log.

--- a/.planning/quick/260713-js8-add-re-crop-trigger-for-existing-profile/260713-js8-CONTEXT.md
+++ b/.planning/quick/260713-js8-add-re-crop-trigger-for-existing-profile/260713-js8-CONTEXT.md
@@ -1,0 +1,72 @@
+# Quick Task 260713-js8: Add re-crop trigger for existing profile images - Context
+
+**Gathered:** 2026-07-13
+**Status:** Ready for planning
+
+<domain>
+## Task Boundary
+
+Photos can be uploaded in exactly 3 places, each with its own controller + view + service/repository stack:
+
+1. **Character profile picture** — `CharactersController` (Create/Edit), `Views/Characters/Create.cshtml` + `Edit.cshtml` (+ `.Mobile.cshtml` variants), `CharacterService`, `CharacterRepository`.
+2. **Contact image** — `ContactsController` (Create/Edit), `Views/Contacts/Create.cshtml` + `Edit.cshtml` (+ `.Mobile.cshtml` variants), `ContactService`, `ContactRepository`.
+3. **DM profile photo** — `DungeonMasterController.EditProfile`, `Views/DungeonMaster/EditProfile.cshtml` (+ `.Mobile.cshtml`), `DungeonMasterProfileService`, `DungeonMasterProfileRepository`.
+
+All three already store an **Original** image and a separately-cropped **Cropped** image (dual-image storage, shipped in v7.0 milestone phases 45/46). The intent (confirmed by the user) was to let a user re-open the cropper against the **already-stored original** without re-uploading a file — i.e. fix a bad crop after the fact. That trigger does not exist today; only Create/Edit's file-input `change` event opens the crop modal (shared `wwwroot/js/image-crop.js`, `initImageCrop()`).
+
+Re-crop only applies on **Edit** views (Create has no existing image yet).
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Scope
+- Fix all three locations (Character, Contact, DM Profile) in this task — confirmed with user via AskUserQuestion, "Fix all three" selected over "Character + Contact only."
+- DM Profile requires materially more work than the other two (new endpoint + service/repository fix) — see Specific Ideas below. Do not treat it as a copy-paste of the Character/Contact pattern.
+
+### Re-crop source image
+- Re-crop must load the **original** (uncropped) stored image into the cropper, not the previously-saved crop. Re-cropping the already-cropped square would prevent recovering parts of the photo that a bad first crop cut away, which defeats the point of the feature.
+- Character and Contact already expose original-image endpoints (`GetProfilePicture`, `GetContactImage`) — reuse them as the fetch source for the re-crop button.
+- DM Profile has **no such endpoint today** (`GetDMProfilePicture` only returns the cropped/fallback image). A new endpoint exposing the DM profile's original image must be added, with the same authorization/visibility checks as the existing `GetDMProfilePicture` (see `IsTargetInActiveGroupAsync` guard at `DungeonMasterController.cs:153`).
+
+### GIF handling (Claude's discretion — not discussed with user, use judgment during planning/execution)
+- On upload, GIFs intentionally skip the crop modal entirely (`image-crop.js` lines ~191-199: cropping would collapse an animated GIF to a static JPEG frame). No stored crop is ever created for a GIF-only original.
+- The re-crop trigger should not silently convert a stored animated GIF into a static cropped JPEG. Recommended approach: detect content-type at click-time from the fetched original-image response (`Content-Type` header) before opening the modal — mirrors the existing `file.type === 'image/gif'` check in the upload path — and show a message instead of opening the modal when the original is a GIF, rather than adding a new server-rendered flag to each ViewModel.
+
+### UI pattern
+- Add a small button/link (e.g. "Edit Crop" / "Re-crop Photo", icon `fa-crop-alt` to match the existing modal's icon) next to the existing photo preview `<img>` in each Edit view (desktop + mobile variants — 3 features x up to 2 view files each, check whether `.Mobile.cshtml` variants share the photo markup or duplicate it).
+- Clicking the button fetches the original image, feeds it into the same shared crop modal/pipeline (`#cropPhotoModal`, `image-crop.js`), and on confirm populates the same hidden `CroppedPictureFile` input already present in each form — the user still clicks the existing "Save"/"Save Changes"/"Save Profile" submit button to persist it. Do not auto-submit the form from the crop-confirm handler; keep the existing save flow untouched.
+- The button only makes sense when a photo already exists (`Model.HasProfilePicture` is already the guard used for the existing preview `<img>` in all 3 views) — gate the button on the same flag.
+
+</decisions>
+
+<specifics>
+## Specific Ideas
+
+### Confirmed backend gaps (from direct investigation of the codebase, not assumption)
+
+**Character & Contact (lower risk):**
+- `CharacterService.UpdateAsync(model, hasNewOriginalUpload, newCroppedImageData, token)` at `QuestBoard.Domain/Services/CharacterService.cs:79` already branches on `newCroppedImageData != null` **independent of** `hasNewOriginalUpload` — a crop-only submission (no new original) is already handled correctly at the service+repository layer. Same pattern in `ContactService.UpdateAsync`.
+- BUT `CharactersController.Edit` (`QuestBoard.Service/Controllers/Characters/CharactersController.cs:269-307`) and `ContactsController.Edit` (similar structure, ~line 200-244) only read `viewModel.CroppedPictureFile` **inside** the `if (hasNewOriginalUpload)` block. A submitted crop-only file is silently dropped by the controller today — this must be restructured so `CroppedPictureFile` is read (and validated, and copied to bytes) regardless of whether `ProfilePictureFile`/`ContactImageFile` was also submitted, then passed through as `newCroppedImageData` to the existing service call.
+- `ImageValidationService.ValidateImagePair(original, cropped)` currently requires an `original` `ImageFileInput` to validate a `cropped` one (see call sites) — check whether a crop-only submission needs a different validation path (e.g. `ValidateSingle` on just the cropped file) since there's no new `original` `IFormFile` to build an `ImageFileInput` from in that case.
+
+**DM Profile (higher risk — do not copy the Character/Contact pattern blindly):**
+- `DungeonMasterProfileService.UpsertProfileAsync` (`QuestBoard.Domain/Services/DungeonMasterProfileService.cs:17`) computes `var updateImage = imageBytes != null || removeImage;` — this ignores `newCroppedImageData` entirely, so a crop-only submission would currently be a no-op even if the controller passed it through.
+- `DungeonMasterProfileRepository.ApplyProfileImage` (`QuestBoard.Repository/DungeonMasterProfileRepository.cs:107`) treats `originalImageData == null` as "**delete the entire stored image**" (`entity.ProfileImage = null`). Character/Contact avoid this because their service layer always re-fetches the existing original from the repository on a no-upload edit before calling `ApplyProfileImage` (e.g. `CharacterService.UpdateAsync` line ~110-112: `await repository.GetCharacterOriginalPictureAsync(...)`). `DungeonMasterProfileService` has no equivalent re-fetch step today — wiring `newCroppedImageData` through naively (with `imageBytes == null`) would **wipe the DM's stored photo**. The fix must add a re-fetch-existing-original step (there's already `GetOriginalPictureAsync` on `DungeonMasterProfileRepository`/`IDungeonMasterProfileRepository`, currently used elsewhere) so `originalImageData` passed to `ApplyProfileImage` is never null on a crop-only edit.
+- No endpoint exposes the DM profile's original (uncropped) image today. `DungeonMasterController.GetDMProfilePicture` (`QuestBoard.Service/Controllers/DungeonMaster/DungeonMasterController.cs:151`) only returns `dmProfileService.GetCroppedPictureAsync(id, ...)`. A new action (e.g. `GetOriginalDMProfilePicture`) is needed, following the same `IsTargetInActiveGroupAsync` guard and MIME-sniff pattern already used in that controller.
+
+### Existing test conventions to follow
+- Unit tests: `QuestBoard.UnitTests/Services/CharacterServiceTests.cs`, `ContactServiceTests.cs`, `DungeonMasterProfileServiceTests.cs` already have crop-related test names to pattern-match against, e.g. `UpdateAsync_NewCropSupplied_PersistsCrop`, `UpdateAsync_NoNewFile_RefetchesAndPassesThroughExistingCrop`. A new crop-only-no-original-upload scenario should get an equivalent test in each.
+- Integration tests: `QuestBoard.IntegrationTests/Controllers/CharactersControllerIntegrationTests.cs` and `ContactsControllerIntegrationTests.cs` already cover `Edit_NewOriginalAndCroppedPhotoUpload_PersistsSubmittedCrop` — a crop-only equivalent (no new original file in the request) should be added per controller, plus a DM Profile integration test that specifically asserts the photo is **not wiped** on a crop-only save (given the risk identified above).
+- `image-crop.js` is one shared file across all 3 views (`initImageCrop()` is called with per-view element IDs/config) — any client-side changes to support loading a fetched image (vs. a locally-picked `File`) belong there once, not duplicated per view.
+
+</specifics>
+
+<canonical_refs>
+## Canonical References
+
+- `.planning/milestones/v7.0-phases/45-dual-image-storage-backend/` — original backend design for Original+Cropped dual storage.
+- `.planning/milestones/v7.0-phases/46-client-side-crop-ui/` — original client-side Cropper.js integration design (the modal/JS this task extends).
+
+</canonical_refs>

--- a/.planning/quick/260713-js8-add-re-crop-trigger-for-existing-profile/260713-js8-PLAN.md
+++ b/.planning/quick/260713-js8-add-re-crop-trigger-for-existing-profile/260713-js8-PLAN.md
@@ -1,0 +1,229 @@
+---
+phase: 260713-js8-add-re-crop-trigger-for-existing-profile
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - QuestBoard.Domain/Services/DungeonMasterProfileService.cs
+  - QuestBoard.Service/Controllers/DungeonMaster/DungeonMasterController.cs
+  - QuestBoard.Service/Controllers/Characters/CharactersController.cs
+  - QuestBoard.Service/Controllers/Contacts/ContactsController.cs
+  - QuestBoard.Service/wwwroot/js/image-crop.js
+  - QuestBoard.Service/Views/Characters/Edit.cshtml
+  - QuestBoard.Service/Views/Characters/Edit.Mobile.cshtml
+  - QuestBoard.Service/Views/Contacts/Edit.cshtml
+  - QuestBoard.Service/Views/Contacts/Edit.Mobile.cshtml
+  - QuestBoard.Service/Views/DungeonMaster/EditProfile.cshtml
+  - QuestBoard.Service/Views/DungeonMaster/EditProfile.Mobile.cshtml
+  - QuestBoard.UnitTests/Services/DungeonMasterProfileServiceTests.cs
+  - QuestBoard.UnitTests/Services/CharacterServiceTests.cs
+  - QuestBoard.UnitTests/Services/ContactServiceTests.cs
+  - QuestBoard.IntegrationTests/Controllers/DungeonMasterControllerIntegrationTests.cs
+  - QuestBoard.IntegrationTests/Controllers/CharactersControllerIntegrationTests.cs
+  - QuestBoard.IntegrationTests/Controllers/ContactsControllerIntegrationTests.cs
+autonomous: true
+requirements: [js8-recrop]
+
+must_haves:
+  truths:
+    - "Each Edit view (Character, Contact, DM Profile) with an existing photo shows a Re-crop trigger that opens the crop modal loaded with the stored ORIGINAL (uncropped) image."
+    - "Confirming a re-crop and clicking the existing Save button persists the new crop WITHOUT requiring a new file upload."
+    - "A DM Profile crop-only save preserves the stored original photo — it is never wiped."
+    - "Character and Contact crop-only saves persist the submitted crop and preserve the stored original."
+    - "An animated GIF original is not silently converted to a static cropped JPEG — the re-crop trigger refuses and shows a message instead."
+  artifacts:
+    - "QuestBoard.Service/Controllers/DungeonMaster/DungeonMasterController.cs — new GetOriginalDMProfilePicture action"
+    - "QuestBoard.Service/wwwroot/js/image-crop.js — re-crop trigger wired via new config keys"
+    - "Re-crop button present in all 6 Edit views"
+    - "DungeonMasterProfileServiceTests crop-only test asserting the photo is NOT wiped"
+    - "Crop-only integration tests for all 3 controllers"
+  key_links:
+    - "image-crop.js re-crop handler → original-image endpoints (GetProfilePicture / GetContactImage / GetOriginalDMProfilePicture)"
+    - "Controllers read CroppedPictureFile independent of new-original presence → service newCroppedImageData"
+    - "DungeonMasterProfileService re-fetches the existing original on a crop-only edit → ApplyProfileImage never receives a null original (which would delete the image)"
+---
+
+<objective>
+Add a "Re-crop Photo" trigger to the three profile-image Edit flows (Character, Contact, DM Profile) that re-opens the shared crop modal against the already-stored ORIGINAL image — no re-upload required — and fix the backend gaps that would otherwise drop or wipe a crop-only submission.
+
+Purpose: The dual-image storage shipped in v7.0 (Original + Cropped) was meant to let a user fix a bad crop after the fact, but no trigger to re-open the cropper against the stored original was ever added, and three backend codepaths silently drop or (for DM Profile) delete the photo on a crop-only save.
+
+Output:
+- New DM endpoint exposing the DM's original image, guarded identically to GetDMProfilePicture.
+- DungeonMasterProfileService fix so a crop-only save re-fetches the existing original (no image wipe).
+- Character/Contact/DM controllers read+validate+persist CroppedPictureFile regardless of whether a new original was uploaded.
+- Shared client-side re-crop trigger in image-crop.js, wired into all 6 Edit views.
+- Unit + integration test coverage for the crop-only scenarios, including a DM test asserting the photo is NOT wiped.
+
+No EF migration is needed — this wires existing Original/Cropped columns through new codepaths; it does not add or change any schema.
+</objective>
+
+<execution_context>
+@$HOME/.claude/gsd-core/workflows/execute-plan.md
+@$HOME/.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/quick/260713-js8-add-re-crop-trigger-for-existing-profile/260713-js8-CONTEXT.md
+@CLAUDE.md
+
+# Backend under change
+@QuestBoard.Domain/Services/DungeonMasterProfileService.cs
+@QuestBoard.Repository/DungeonMasterProfileRepository.cs
+@QuestBoard.Service/Controllers/DungeonMaster/DungeonMasterController.cs
+@QuestBoard.Service/Controllers/Characters/CharactersController.cs
+@QuestBoard.Service/Controllers/Contacts/ContactsController.cs
+@QuestBoard.Domain/Services/CharacterService.cs
+@QuestBoard.Domain/Services/ImageValidationService.cs
+
+# Frontend under change
+@QuestBoard.Service/wwwroot/js/image-crop.js
+
+# Test conventions to mirror
+@QuestBoard.UnitTests/Services/DungeonMasterProfileServiceTests.cs
+@QuestBoard.IntegrationTests/Controllers/CharactersControllerIntegrationTests.cs
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Fix DM Profile crop-only backend (no-wipe service fix + original-image endpoint + controller restructure)</name>
+  <files>QuestBoard.Domain/Services/DungeonMasterProfileService.cs, QuestBoard.Service/Controllers/DungeonMaster/DungeonMasterController.cs</files>
+  <behavior>
+    - A crop-only UpsertProfileAsync (imageBytes null, removeImage false, newCroppedImageData non-null) on an existing profile persists the new crop AND leaves the stored original bytes unchanged.
+    - A bio-only edit (all image inputs absent) still leaves both original and crop untouched.
+    - A new-original edit and an explicit removeImage still behave exactly as today.
+    - GetOriginalDMProfilePicture returns the original (uncropped) bytes with a sniffed content-type for a target in the caller's active group, and NotFound when the target is outside the active group or has no image.
+  </behavior>
+  <action>
+In DungeonMasterProfileService.UpsertProfileAsync: the current updateImage flag is computed only from imageBytes and removeImage, so it ignores newCroppedImageData and a crop-only save is a no-op; and when it does write, ApplyProfileImage in the repository treats a null original as "delete the whole image", which would wipe the DM's photo. Fix both: (a) include a crop as a reason to write, i.e. treat updateImage as true when imageBytes is non-null OR removeImage is true OR newCroppedImageData is non-null; (b) compute the original bytes to pass down into a local — normally the existing remove-or-imageBytes expression — but when this is a crop-only edit (imageBytes null AND removeImage false AND newCroppedImageData non-null), re-fetch the existing original via repository.GetOriginalPictureAsync(userId, token) and pass THAT as originalImageData so ApplyProfileImage never receives a null original on a crop-only save. Pass this computed originalImageData local (not the inline remove-or-imageBytes expression) into both UpdateBioWithProfileImageAsync call sites (the lazy-create branch and the existing-profile branch). This mirrors the re-fetch-existing-original step CharacterService.UpdateAsync already performs on a no-upload edit. Do not change the repository or the interface — GetOriginalPictureAsync already exists on IDungeonMasterProfileRepository.
+
+Add a new GetOriginalDMProfilePicture(int id, CancellationToken) action to DungeonMasterController, modeled on the existing GetDMProfilePicture action directly above IsTargetInActiveGroupAsync: apply the same IsTargetInActiveGroupAsync(id) guard returning NotFound on failure, fetch bytes from dmProfileService.GetProfilePictureAsync(id, token) (this returns the ORIGINAL, unlike GetDMProfilePicture which returns the cropped/fallback), return NotFound when bytes are null or empty, and return File(...) with the same magic-byte content-type sniff GetDMProfilePicture uses (PNG then GIF then JPEG fallback).
+
+Restructure the EditProfile POST action so a crop-only submission is read, validated, and persisted. Today ProfilePictureFile presence gates everything, and CroppedPictureFile is only read inside that block. Change it to: build an ImageFileInput for the original only when a new ProfilePictureFile was uploaded (else null); build an ImageFileInput for the crop whenever CroppedPictureFile has a positive Length (else null); when either is non-null, call imageValidationService.ValidateImagePair(original, cropped) — note ValidateImagePair tolerates a null original and validates just the crop, so no new validation method is needed — add any errors to ModelState and return View(viewModel) if invalid; copy ProfilePictureFile bytes into imageBytes only when a new original was uploaded; copy CroppedPictureFile bytes into newCroppedImageData whenever a crop was submitted. Keep the existing UpsertProfileAsync call unchanged in shape (it already forwards newCroppedImageData). Do not add planning/tracking IDs to any comment (see CLAUDE.md Code Comments).
+  </action>
+  <verify>
+    <automated>dotnet build QuestBoard.sln</automated>
+  </verify>
+  <done>Solution compiles. UpsertProfileAsync re-fetches the existing original on a crop-only edit and includes a crop in updateImage; GetOriginalDMProfilePicture exists with the IsTargetInActiveGroupAsync guard and returns the original bytes; EditProfile POST reads/validates/persists CroppedPictureFile even when no new ProfilePictureFile was uploaded.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Read crop-only submissions in Character and Contact Edit controllers</name>
+  <files>QuestBoard.Service/Controllers/Characters/CharactersController.cs, QuestBoard.Service/Controllers/Contacts/ContactsController.cs</files>
+  <action>
+Both CharactersController.Edit and ContactsController.Edit currently read CroppedPictureFile ONLY inside the hasNewOriginalUpload block, so a crop-only submission (no new original) is silently dropped by the controller — even though CharacterService.UpdateAsync and ContactService.UpdateAsync already handle a non-null newCroppedImageData independently of hasNewOriginalUpload. Restructure each Edit POST so the crop is read regardless of whether a new original was also uploaded, keeping hasNewOriginalUpload as the single source of truth for the original-file handling.
+
+For each controller: keep the existing hasNewOriginalUpload local (the uploaded-original file is non-null with positive Length). Build the original ImageFileInput only when hasNewOriginalUpload (else null); build the crop ImageFileInput whenever CroppedPictureFile has a positive Length (else null). When either input is non-null, call imageValidationService.ValidateImagePair(original, cropped), add errors to ModelState, and on invalid ModelState re-set the view flag the existing code sets before returning View (Character: viewModel.IsOwner from existingCharacter.OwnerId vs currentUser.Id; Contact: viewModel.CanManage = true) then return View(viewModel). Only when hasNewOriginalUpload, copy the uploaded original bytes into the existing entity field (existingCharacter.ProfilePicture / existingContact.ContactImageData). Whenever a crop was submitted, copy its bytes into newCroppedImageData. Leave the existing service call unchanged — UpdateAsync(entity, hasNewOriginalUpload, newCroppedImageData, token) already carries the crop through, and on a crop-only edit the service re-fetches the stored original itself, so the entity's original field being untouched is correct. Do not add planning/tracking IDs to any comment (CLAUDE.md).
+  </action>
+  <verify>
+    <automated>dotnet build QuestBoard.sln</automated>
+  </verify>
+  <done>Both controllers read, validate, and forward CroppedPictureFile on a crop-only edit (no new original file), the original-file byte copy stays gated on hasNewOriginalUpload, and the solution compiles.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Add re-crop trigger support to the shared image-crop.js pipeline</name>
+  <files>QuestBoard.Service/wwwroot/js/image-crop.js</files>
+  <action>
+Extend the shared initImageCrop() so a view can wire a "re-crop the stored original" button, reusing the same modal, crop extraction, and hidden-input population already in the file.
+
+First refactor to avoid duplication: extract the portion of the fileInput change handler that runs after prepareImageForCropper succeeds — from the object-URL swap through the fit-image-and-selection wiring and the modal show call — into a new reusable async inner function (e.g. openCropperWithPreparedBlob(correctedBlob)) defined alongside the other inner helpers. Have the change handler call it after prepareImageForCropper returns.
+
+Add two new optional config keys read at the top of initImageCrop: recropButtonId and originalImageUrl. Resolve recropBtn via getElementById(recropButtonId) when provided; if the button is absent, do nothing (safe no-op, matching how a missing fileInput is handled) so views without an existing photo stay unaffected.
+
+When recropBtn exists, wire a click handler that: clears any prior read error; fetches originalImageUrl with cache disabled (no-store); on a non-ok response or a thrown error, shows the existing read-error message and returns; reads the response Content-Type header and, when it indicates an animated GIF, calls showError with a message explaining the stored photo is an animated GIF and can't be re-cropped without losing its animation, then returns — this mirrors the existing image/gif skip in the upload path so a stored GIF is never collapsed to a static JPEG. Otherwise: read the response body as a blob, wrap it in a File carrying the returned content-type, set currentOriginalFileName to a sensible default such as photo, run prepareImageForCropper on that File (showing the read-error message and returning on failure), then call the shared openCropperWithPreparedBlob. The existing confirm and cancel handlers and the hidden CroppedPictureFile population require no change — the re-crop path reuses them, so on confirm the user still saves via the form's existing submit button.
+  </action>
+  <verify>
+    <automated>grep -q openCropperWithPreparedBlob QuestBoard.Service/wwwroot/js/image-crop.js && grep -q recropButtonId QuestBoard.Service/wwwroot/js/image-crop.js && grep -q originalImageUrl QuestBoard.Service/wwwroot/js/image-crop.js && echo OK</automated>
+  </verify>
+  <done>image-crop.js exposes recropButtonId/originalImageUrl config, shares the modal-open path via openCropperWithPreparedBlob, fetches the stored original, refuses animated GIFs with a message, and reuses the existing confirm/cancel/hidden-input logic.</done>
+</task>
+
+<task type="auto">
+  <name>Task 4: Wire the Re-crop Photo button into all 6 Edit views</name>
+  <files>QuestBoard.Service/Views/Characters/Edit.cshtml, QuestBoard.Service/Views/Characters/Edit.Mobile.cshtml, QuestBoard.Service/Views/Contacts/Edit.cshtml, QuestBoard.Service/Views/Contacts/Edit.Mobile.cshtml, QuestBoard.Service/Views/DungeonMaster/EditProfile.cshtml, QuestBoard.Service/Views/DungeonMaster/EditProfile.Mobile.cshtml</files>
+  <action>
+In each of the 6 Edit views, add a re-crop trigger button and pass the new config keys to the existing initImageCrop call. The button belongs INSIDE the existing photo-preview block (the block already gated on Model.HasProfilePicture for Character/DM, or Model.HasContactImage for Contact), immediately after the preview img, so it only renders when a photo already exists. Use a filled small button following the CLAUDE.md modern-card convention (not outline) with the fa-crop-alt icon and me-1 icon spacing — e.g. a small warning-styled button labeled "Re-crop Photo", with id recropPhotoBtn (the same id in every view is fine — each page loads one view). Do not add a second hidden input or a second modal; the existing hidden CroppedPictureFile input and cropPhotoModal markup are reused.
+
+Update the initImageCrop({ ... }) call in each view's Scripts section to add recropButtonId: 'recropPhotoBtn' and originalImageUrl pointing at the ORIGINAL-image endpoint (NOT the cropped preview endpoint) via Url.Action, so the cropper loads the uncropped source:
+- Characters Edit.cshtml and Edit.Mobile.cshtml → Url.Action GetProfilePicture with id = Model.Id
+- Contacts Edit.cshtml and Edit.Mobile.cshtml → Url.Action GetContactImage with id = Model.Id
+- DungeonMaster EditProfile.cshtml and EditProfile.Mobile.cshtml → Url.Action GetOriginalDMProfilePicture with id = Model.DungeonMasterId (the new endpoint from Task 1)
+Keep the existing fileInputId, hiddenCroppedInputName, and aspectRatio arguments unchanged in each call.
+  </action>
+  <verify>
+    <automated>test $(grep -rl recropPhotoBtn QuestBoard.Service/Views/Characters/Edit.cshtml QuestBoard.Service/Views/Characters/Edit.Mobile.cshtml QuestBoard.Service/Views/Contacts/Edit.cshtml QuestBoard.Service/Views/Contacts/Edit.Mobile.cshtml QuestBoard.Service/Views/DungeonMaster/EditProfile.cshtml QuestBoard.Service/Views/DungeonMaster/EditProfile.Mobile.cshtml | wc -l) -eq 6 && dotnet build QuestBoard.Service/QuestBoard.Service.csproj</automated>
+  </verify>
+  <done>All 6 Edit views contain the recropPhotoBtn (gated on the existing photo-present flag), each initImageCrop call passes recropButtonId and the correct original-image originalImageUrl, and the Service project compiles.</done>
+</task>
+
+<task type="auto">
+  <name>Task 5: Unit tests for crop-only service behavior (DM no-wipe, Character, Contact)</name>
+  <files>QuestBoard.UnitTests/Services/DungeonMasterProfileServiceTests.cs, QuestBoard.UnitTests/Services/CharacterServiceTests.cs, QuestBoard.UnitTests/Services/ContactServiceTests.cs</files>
+  <action>
+Add a crop-only-without-new-original unit test to each service test class, matching the existing arrange/act/assert style, seed helpers, and FluentAssertions usage already in those files.
+
+DungeonMasterProfileServiceTests (the critical no-wipe assertion): using the existing SeedDungeonMasterProfileWithImagesAsync helper to seed original A + crop A, call UpsertProfileAsync with imageBytes null, removeImage false, and a real newCroppedImageData B (bio unchanged). Assert GetCroppedPictureAsync returns B AND GetOriginalPictureAsync still returns A (the original is preserved, NOT wiped to null). Name it in the established convention, e.g. UpsertProfileAsync_CropOnlyNoNewOriginal_PersistsCropAndPreservesOriginal.
+
+CharacterServiceTests and ContactServiceTests: mirror the existing UpdateAsync_NoNewFile_RefetchesAndPassesThroughExistingCrop / UpdateAsync_NewCropSupplied_PersistsCrop tests but for the crop-only-on-edit path — call UpdateAsync(model, hasNewOriginalUpload: false, newCroppedImageData: B, token) against a seeded original A + crop A, and assert the stored cropped image becomes B while the stored original remains A. Reuse whatever repository/seed/mapper setup those files already use; do not introduce new test infrastructure.
+  </action>
+  <verify>
+    <automated>dotnet test QuestBoard.UnitTests/QuestBoard.UnitTests.csproj --filter "FullyQualifiedName~DungeonMasterProfileServiceTests|FullyQualifiedName~CharacterServiceTests|FullyQualifiedName~ContactServiceTests"</automated>
+  </verify>
+  <done>Each of the three service test classes has a passing crop-only test; the DM test proves the original is preserved (not wiped) and the crop is persisted on a crop-only save.</done>
+</task>
+
+<task type="auto">
+  <name>Task 6: Integration tests for crop-only POST across all 3 controllers</name>
+  <files>QuestBoard.IntegrationTests/Controllers/CharactersControllerIntegrationTests.cs, QuestBoard.IntegrationTests/Controllers/ContactsControllerIntegrationTests.cs, QuestBoard.IntegrationTests/Controllers/DungeonMasterControllerIntegrationTests.cs</files>
+  <action>
+Add a crop-only integration test to each controller test class, mirroring the existing multipart Edit tests (for Characters, follow Edit_NewOriginalAndCroppedPhotoUpload_PersistsSubmittedCrop: same auth-client, seed helpers, MultipartFormDataContent, and image-entity assertions). The distinguishing property of these new tests: the multipart body includes CroppedPictureFile but NO ProfilePictureFile / ContactImageFile / DM original file.
+
+Characters and Contacts: seed the target with original A + crop A on the image entity, POST an Edit request whose multipart body carries only a new CroppedPictureFile B (all other required form fields present, no original-file part), expect the redirect, then load the image entity and assert CroppedImageData equals B while OriginalImageData still equals A.
+
+DungeonMaster (the explicit no-wipe assertion required by the task): seed a DM profile with original A + crop A, POST an EditProfile request (route id = the DM user id) whose multipart body carries Bio, the anti-forgery/required fields, and only a new CroppedPictureFile B — no original file part. After the redirect, load the DungeonMasterProfileImageEntity and assert OriginalImageData is unchanged (equals A and is NOT null) AND CroppedImageData equals B. Reuse the auth/group setup helpers already used by the other tests in DungeonMasterControllerIntegrationTests; do not add new harness code. Name each test in the established convention (e.g. Edit_CropOnlyNoNewOriginal_PersistsCropAndPreservesOriginal / EditProfile_CropOnlyNoNewOriginal_PreservesStoredOriginal).
+  </action>
+  <verify>
+    <automated>dotnet test QuestBoard.IntegrationTests/QuestBoard.IntegrationTests.csproj --filter "FullyQualifiedName~CharactersControllerIntegrationTests|FullyQualifiedName~ContactsControllerIntegrationTests|FullyQualifiedName~DungeonMasterControllerIntegrationTests"</automated>
+  </verify>
+  <done>Each controller has a passing crop-only integration test posting a crop without a new original; the DM test proves the stored photo is preserved (OriginalImageData not null, still equals the seeded bytes) and the new crop is persisted.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| browser → DungeonMaster/GetOriginalDMProfilePicture | Authenticated caller requests a DM's original (uncropped) image bytes by user id |
+| browser form → Edit POST actions | Multipart submission carrying image bytes crosses into persistence |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Severity | Disposition | Mitigation Plan |
+|-----------|----------|-----------|----------|-------------|-----------------|
+| T-js8-01 | Information Disclosure | GetOriginalDMProfilePicture (new endpoint) | medium | mitigate | Reuse the existing IsTargetInActiveGroupAsync(id) guard exactly as GetDMProfilePicture does, so a caller cannot fetch original images for users outside their active group by guessing ids |
+| T-js8-02 | Denial of Service / data integrity | DungeonMasterProfileService.UpsertProfileAsync crop-only path | high | mitigate | Re-fetch the stored original before ApplyProfileImage so a crop-only save never passes a null original (which the repository interprets as delete-the-whole-image); covered by the DM no-wipe unit + integration tests |
+| T-js8-03 | Tampering | Crop-only image validation | low | mitigate | Route the submitted CroppedPictureFile through the existing ImageValidationService.ValidateImagePair (type/extension/size checks) before persisting, even when no new original accompanies it |
+</threat_model>
+
+<verification>
+- `dotnet build QuestBoard.sln` succeeds after all backend and view changes.
+- `dotnet test QuestBoard.UnitTests/QuestBoard.UnitTests.csproj` passes, including the new crop-only service tests (DM no-wipe, Character, Contact).
+- `dotnet test QuestBoard.IntegrationTests/QuestBoard.IntegrationTests.csproj` passes, including the new crop-only POST tests for all 3 controllers.
+- Manual (optional, per CLAUDE.md run skill): on an Edit page with an existing photo, the Re-crop Photo button opens the crop modal loaded with the uncropped original; confirming and saving updates the displayed image; saving a re-crop does not remove the DM photo; an animated-GIF original shows the refusal message instead of opening the modal.
+</verification>
+
+<success_criteria>
+- All three Edit flows expose a working Re-crop trigger gated on an existing photo, loading the stored ORIGINAL into the shared cropper.
+- A crop-only save persists the new crop in all three flows and preserves the stored original — DM Profile specifically is never wiped.
+- Animated GIF originals are not silently flattened to static crops.
+- No EF migration added; no user-facing flow broken; solution builds and all new + existing tests pass.
+</success_criteria>
+
+<output>
+Create `.planning/quick/260713-js8-add-re-crop-trigger-for-existing-profile/260713-js8-01-SUMMARY.md` when done.
+</output>

--- a/QuestBoard.Domain/Services/DungeonMasterProfileService.cs
+++ b/QuestBoard.Domain/Services/DungeonMasterProfileService.cs
@@ -21,7 +21,12 @@ internal class DungeonMasterProfileService(IDungeonMasterProfileRepository repos
         //                        non-null here already means a genuinely new original arrived --
         //                        unless newCroppedImageData supplies a real replacement crop.
         // removeImage == true  → explicitly clear the stored image (e.g. "remove photo" button)
-        // both false/null     → keep existing image unchanged (bio-only edit) -- the crop is
+        // newCroppedImageData only (imageBytes null, removeImage false) → a crop-only re-save --
+        //                        the caller re-cropped the already-stored original without
+        //                        re-uploading it, so the original must be re-fetched below
+        //                        rather than passed through as null (which the repository would
+        //                        otherwise interpret as "delete the image").
+        // all three absent    → keep existing image unchanged (bio-only edit) -- the crop is
         //                        preserved by construction, since the image is never touched on
         //                        this path.
         //
@@ -29,7 +34,13 @@ internal class DungeonMasterProfileService(IDungeonMasterProfileRepository repos
         // repository call so a failure in either half cannot leave the profile in a
         // half-updated state (new photo, stale bio, or vice versa).
         var profile = await repository.GetProfileByUserIdAsync(userId, token);
-        var updateImage = imageBytes != null || removeImage;
+        var updateImage = imageBytes != null || removeImage || newCroppedImageData != null;
+
+        var isCropOnlyEdit = imageBytes == null && !removeImage && newCroppedImageData != null;
+        var originalImageData = isCropOnlyEdit
+            ? await repository.GetOriginalPictureAsync(userId, token)
+            : removeImage ? null : imageBytes;
+
         if (profile == null)
         {
             // Lazy create — profile entity does not exist until DM first saves. AddAsync must
@@ -40,11 +51,11 @@ internal class DungeonMasterProfileService(IDungeonMasterProfileRepository repos
             var newProfile = new DungeonMasterProfile { Id = userId, Bio = bio };
             await repository.AddAsync(newProfile, token);
             if (updateImage)
-                await repository.UpdateBioWithProfileImageAsync(userId, bio, updateImage: true, removeImage ? null : imageBytes, croppedImageData: newCroppedImageData, token);
+                await repository.UpdateBioWithProfileImageAsync(userId, bio, updateImage: true, originalImageData, croppedImageData: newCroppedImageData, token);
         }
         else
         {
-            await repository.UpdateBioWithProfileImageAsync(userId, bio, updateImage, removeImage ? null : imageBytes, croppedImageData: newCroppedImageData, token);
+            await repository.UpdateBioWithProfileImageAsync(userId, bio, updateImage, originalImageData, croppedImageData: newCroppedImageData, token);
         }
     }
 

--- a/QuestBoard.IntegrationTests/Controllers/CharactersControllerIntegrationTests.cs
+++ b/QuestBoard.IntegrationTests/Controllers/CharactersControllerIntegrationTests.cs
@@ -840,6 +840,72 @@ public class CharactersControllerIntegrationTests(WebApplicationFactoryBase fact
         persistedImage!.OriginalImageData.Should().Equal(originalBytes);
     }
 
+    // Proves a crop-only submission (re-cropping the stored original without re-uploading a new
+    // ProfilePictureFile) is read, validated, and persisted by the controller, and the stored
+    // original survives untouched.
+    [Fact]
+    public async Task Edit_CropOnlyNoNewOriginal_PersistsCropAndPreservesOriginal()
+    {
+        // Arrange
+        await TestDataHelper.ClearDatabaseAsync(factory.Services);
+
+        var (ownerClient, owner) = await AuthenticationHelper.CreateAuthenticatedClientWithUserAsync(
+            factory, "owner_recrop_only", "owner_recrop_only@example.com");
+        var character = await TestDataHelper.CreateTestCharacterAsync(
+            factory.Services, owner.Id, "Character Getting Re-Cropped", groupId: 1);
+
+        byte[] originalBytes = [1, 2, 3, 4];
+        byte[] staleCroppedBytes = [9, 9, 9, 9];
+        byte[] newCropBytes = [200, 201, 202, 203];
+
+        using (var seedScope = factory.Services.CreateScope())
+        {
+            var seedContext = seedScope.ServiceProvider.GetRequiredService<QuestBoardContext>();
+            seedContext.Set<CharacterImageEntity>().Add(new CharacterImageEntity
+            {
+                Id = character.Id,
+                OriginalImageData = originalBytes,
+                CroppedImageData = staleCroppedBytes
+            });
+            await seedContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        using var formContent = new MultipartFormDataContent
+        {
+            { new StringContent(character.Id.ToString()), "Id" },
+            { new StringContent(owner.Id.ToString()), "OwnerId" },
+            { new StringContent("Character Getting Re-Cropped"), "Name" },
+            { new StringContent("5"), "Level" },
+            { new StringContent(((int)CharacterStatus.Active).ToString()), "Status" },
+            { new StringContent(((int)CharacterRole.Backup).ToString()), "Role" },
+            { new StringContent(""), "SheetLink" },
+            { new StringContent(""), "Description" },
+            { new StringContent(""), "Backstory" },
+            { new StringContent("5"), "Classes[0].Class" }, // Fighter
+            { new StringContent("5"), "Classes[0].ClassLevel" }
+        };
+        // No ProfilePictureFile part -- this is the distinguishing property of a crop-only save.
+        var croppedFileContent = new ByteArrayContent(newCropBytes);
+        croppedFileContent.Headers.ContentType = new MediaTypeHeaderValue("image/png");
+        formContent.Add(croppedFileContent, "CroppedPictureFile", "re-cropped.png");
+
+        // Act
+        var response = await ownerClient.PostAsync(
+            $"/Characters/Edit/{character.Id}", formContent, TestContext.Current.CancellationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        response.Headers.Location!.OriginalString.Should().NotContain("AccessDenied");
+
+        using var scope = factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<QuestBoardContext>();
+        var persistedImage = await context.Set<CharacterImageEntity>().FindAsync(
+            [character.Id], TestContext.Current.CancellationToken);
+        persistedImage.Should().NotBeNull();
+        persistedImage!.CroppedImageData.Should().Equal(newCropBytes);
+        persistedImage.OriginalImageData.Should().Equal(originalBytes);
+    }
+
     // Proves the new GetCroppedPicture read action serves the stored crop.
     [Fact]
     public async Task GetCroppedPicture_CropStored_ReturnsOkWithContent()

--- a/QuestBoard.IntegrationTests/Controllers/ContactsControllerIntegrationTests.cs
+++ b/QuestBoard.IntegrationTests/Controllers/ContactsControllerIntegrationTests.cs
@@ -725,6 +725,62 @@ public class ContactsControllerIntegrationTests(WebApplicationFactoryBase factor
         persistedImage!.OriginalImageData.Should().Equal(originalBytes);
     }
 
+    // Proves a crop-only submission (re-cropping the stored original without re-uploading a new
+    // ContactImageFile) is read, validated, and persisted by the controller, and the stored
+    // original survives untouched.
+    [Fact]
+    public async Task Edit_CropOnlyNoNewOriginal_PersistsCropAndPreservesOriginal()
+    {
+        await TestDataHelper.ClearDatabaseAsync(factory.Services);
+        var (dmClient, dmUser) = await AuthenticationHelper.CreateAuthenticatedClientWithUserAsync(
+            factory, "contact_recrop_only", "contact_recrop_only@example.com", roles: ["DungeonMaster"]);
+        var contact = await TestDataHelper.CreateTestContactAsync(
+            factory.Services, dmUser.Id, "Contact Getting Re-Cropped", groupId: 1);
+
+        byte[] originalBytes = [1, 2, 3, 4];
+        byte[] staleCroppedBytes = [9, 9, 9, 9];
+        byte[] newCropBytes = [200, 201, 202, 203];
+
+        using (var seedScope = factory.Services.CreateScope())
+        {
+            var seedContext = seedScope.ServiceProvider.GetRequiredService<QuestBoardContext>();
+            seedContext.Set<ContactImageEntity>().Add(new ContactImageEntity
+            {
+                Id = contact.Id,
+                OriginalImageData = originalBytes,
+                CroppedImageData = staleCroppedBytes
+            });
+            await seedContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        using var formContent = new MultipartFormDataContent
+        {
+            { new StringContent(contact.Id.ToString()), "Id" },
+            { new StringContent("Contact Getting Re-Cropped"), "Name" },
+            { new StringContent("Waterdeep"), "TownCity" },
+            { new StringContent(""), "SubLocation" },
+            { new StringContent(""), "Description" }
+        };
+        // No ContactImageFile part -- this is the distinguishing property of a crop-only save.
+        var croppedFileContent = new ByteArrayContent(newCropBytes);
+        croppedFileContent.Headers.ContentType = new MediaTypeHeaderValue("image/png");
+        formContent.Add(croppedFileContent, "CroppedPictureFile", "re-cropped.png");
+
+        var response = await dmClient.PostAsync(
+            $"/Contacts/Edit/{contact.Id}", formContent, TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        response.Headers.Location!.OriginalString.Should().NotContain("AccessDenied");
+
+        using var scope = factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<QuestBoardContext>();
+        var persistedImage = await context.Set<ContactImageEntity>().FindAsync(
+            [contact.Id], TestContext.Current.CancellationToken);
+        persistedImage.Should().NotBeNull();
+        persistedImage!.CroppedImageData.Should().Equal(newCropBytes);
+        persistedImage.OriginalImageData.Should().Equal(originalBytes);
+    }
+
     // Visibility parity: the new GetCroppedContactImage read action must apply the identical
     // IsVisibleTo gate as GetContactImage — a hidden contact returns NotFound even though a
     // crop is stored.

--- a/QuestBoard.IntegrationTests/Controllers/DungeonMasterControllerIntegrationTests.cs
+++ b/QuestBoard.IntegrationTests/Controllers/DungeonMasterControllerIntegrationTests.cs
@@ -2,6 +2,7 @@ using QuestBoard.Domain.Enums;
 using QuestBoard.Domain.Interfaces;
 using QuestBoard.IntegrationTests.Helpers;
 using System.Net;
+using System.Net.Http.Headers;
 
 namespace QuestBoard.IntegrationTests.Controllers;
 
@@ -433,5 +434,54 @@ public class DungeonMasterControllerIntegrationTests(WebApplicationFactoryBase f
         response.StatusCode.Should().BeOneOf(HttpStatusCode.Redirect, HttpStatusCode.Found);
         var location = response.Headers.Location?.ToString() ?? string.Empty;
         location.Should().Contain("/groups/pick");
+    }
+
+    // Proves a crop-only submission (re-cropping the stored original without re-uploading a new
+    // ProfilePictureFile) is read, validated, and persisted by EditProfile POST, and — the
+    // explicit no-wipe assertion this task requires — the stored original survives untouched
+    // rather than being deleted by ApplyProfileImage receiving a null original.
+    [Fact]
+    public async Task EditProfile_CropOnlyNoNewOriginal_PreservesStoredOriginal()
+    {
+        await TestDataHelper.ClearDatabaseAsync(factory.Services);
+        var (dmClient, dmUser) = await AuthenticationHelper.CreateAuthenticatedClientWithUserAsync(
+            factory, "dmcroponlyrecrop", "dmcroponlyrecrop@example.com", roles: ["DungeonMaster"]);
+
+        byte[] originalBytes = [1, 2, 3, 4];
+        byte[] staleCroppedBytes = [9, 9, 9, 9];
+        byte[] newCropBytes = [200, 201, 202, 203];
+
+        using (var scope = factory.Services.CreateScope())
+        {
+            var dmProfileService = scope.ServiceProvider.GetRequiredService<IDungeonMasterProfileService>();
+            await dmProfileService.UpsertProfileAsync(
+                dmUser.Id, bio: "Original bio.", imageBytes: originalBytes, newCroppedImageData: staleCroppedBytes,
+                token: TestContext.Current.CancellationToken);
+        }
+
+        using var formContent = new MultipartFormDataContent
+        {
+            { new StringContent(dmUser.Id.ToString()), "DungeonMasterId" },
+            { new StringContent("Original bio."), "Bio" }
+        };
+        // No ProfilePictureFile part -- this is the distinguishing property of a crop-only save.
+        var croppedFileContent = new ByteArrayContent(newCropBytes);
+        croppedFileContent.Headers.ContentType = new MediaTypeHeaderValue("image/png");
+        formContent.Add(croppedFileContent, "CroppedPictureFile", "re-cropped.png");
+
+        var response = await dmClient.PostAsync(
+            $"/DungeonMaster/EditProfile/{dmUser.Id}", formContent, TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        response.Headers.Location!.OriginalString.Should().NotContain("AccessDenied");
+
+        using var scope2 = factory.Services.CreateScope();
+        var context = scope2.ServiceProvider.GetRequiredService<QuestBoardContext>();
+        var persistedImage = await context.Set<DungeonMasterProfileImageEntity>().FindAsync(
+            [dmUser.Id], TestContext.Current.CancellationToken);
+        persistedImage.Should().NotBeNull();
+        persistedImage!.OriginalImageData.Should().NotBeNull();
+        persistedImage.OriginalImageData.Should().Equal(originalBytes);
+        persistedImage.CroppedImageData.Should().Equal(newCropBytes);
     }
 }

--- a/QuestBoard.Service/Controllers/Characters/CharactersController.cs
+++ b/QuestBoard.Service/Controllers/Characters/CharactersController.cs
@@ -268,21 +268,25 @@ namespace QuestBoard.Service.Controllers.Characters
             // two checks can never drift apart.
             var hasNewOriginalUpload = viewModel.ProfilePictureFile != null && viewModel.ProfilePictureFile.Length > 0;
 
-            // Handle profile picture upload - clear old picture first if new one is being uploaded
-            byte[]? newCroppedImageData = null;
-            if (hasNewOriginalUpload)
+            // The crop is read whenever it's submitted, independent of hasNewOriginalUpload, so a
+            // crop-only re-save (re-cropping the stored original without re-uploading it) isn't
+            // silently dropped -- CharacterService.UpdateAsync already handles newCroppedImageData
+            // independently of hasNewOriginalUpload.
+            ImageFileInput? original = hasNewOriginalUpload
+                ? new ImageFileInput(viewModel.ProfilePictureFile!.Length, viewModel.ProfilePictureFile.ContentType,
+                    viewModel.ProfilePictureFile.FileName, nameof(viewModel.ProfilePictureFile))
+                : null;
+
+            ImageFileInput? cropped = null;
+            if (viewModel.CroppedPictureFile is { Length: > 0 } croppedFile)
             {
-                var newProfilePictureFile = viewModel.ProfilePictureFile!;
-                var original = new ImageFileInput(newProfilePictureFile.Length, newProfilePictureFile.ContentType,
-                    newProfilePictureFile.FileName, nameof(viewModel.ProfilePictureFile));
+                cropped = new ImageFileInput(croppedFile.Length, croppedFile.ContentType,
+                    croppedFile.FileName, nameof(viewModel.CroppedPictureFile));
+            }
 
-                ImageFileInput? cropped = null;
-                if (viewModel.CroppedPictureFile is { Length: > 0 } croppedFile)
-                {
-                    cropped = new ImageFileInput(croppedFile.Length, croppedFile.ContentType,
-                        croppedFile.FileName, nameof(viewModel.CroppedPictureFile));
-                }
-
+            byte[]? newCroppedImageData = null;
+            if (original != null || cropped != null)
+            {
                 var validationErrors = imageValidationService.ValidateImagePair(original, cropped);
                 foreach (var error in validationErrors)
                 {
@@ -293,19 +297,22 @@ namespace QuestBoard.Service.Controllers.Characters
                     viewModel.IsOwner = existingCharacter.OwnerId == currentUser.Id;
                     return View(viewModel);
                 }
+            }
 
+            if (hasNewOriginalUpload)
+            {
                 using var memoryStream = new MemoryStream();
-                await newProfilePictureFile.CopyToAsync(memoryStream, token);
+                await viewModel.ProfilePictureFile!.CopyToAsync(memoryStream, token);
                 existingCharacter.ProfilePicture = memoryStream.ToArray();
-
-                if (cropped != null)
-                {
-                    using var croppedStream = new MemoryStream();
-                    await viewModel.CroppedPictureFile!.CopyToAsync(croppedStream, token);
-                    newCroppedImageData = croppedStream.ToArray();
-                }
             }
             // Otherwise, profile picture remains unchanged
+
+            if (cropped != null)
+            {
+                using var croppedStream = new MemoryStream();
+                await viewModel.CroppedPictureFile!.CopyToAsync(croppedStream, token);
+                newCroppedImageData = croppedStream.ToArray();
+            }
 
             // Update classes
             existingCharacter.Classes = mapper.Map<List<CharacterClass>>(viewModel.Classes);

--- a/QuestBoard.Service/Controllers/Contacts/ContactsController.cs
+++ b/QuestBoard.Service/Controllers/Contacts/ContactsController.cs
@@ -199,20 +199,25 @@ namespace QuestBoard.Service.Controllers.Contacts
             // two checks can never drift apart.
             var hasNewOriginalUpload = viewModel.ContactImageFile != null && viewModel.ContactImageFile.Length > 0;
 
-            byte[]? newCroppedImageData = null;
-            if (hasNewOriginalUpload)
+            // The crop is read whenever it's submitted, independent of hasNewOriginalUpload, so a
+            // crop-only re-save (re-cropping the stored original without re-uploading it) isn't
+            // silently dropped -- ContactService.UpdateAsync already handles newCroppedImageData
+            // independently of hasNewOriginalUpload.
+            ImageFileInput? original = hasNewOriginalUpload
+                ? new ImageFileInput(viewModel.ContactImageFile!.Length, viewModel.ContactImageFile.ContentType,
+                    viewModel.ContactImageFile.FileName, nameof(viewModel.ContactImageFile))
+                : null;
+
+            ImageFileInput? cropped = null;
+            if (viewModel.CroppedPictureFile is { Length: > 0 } croppedFile)
             {
-                var newContactImageFile = viewModel.ContactImageFile!;
-                var original = new ImageFileInput(newContactImageFile.Length, newContactImageFile.ContentType,
-                    newContactImageFile.FileName, nameof(viewModel.ContactImageFile));
+                cropped = new ImageFileInput(croppedFile.Length, croppedFile.ContentType,
+                    croppedFile.FileName, nameof(viewModel.CroppedPictureFile));
+            }
 
-                ImageFileInput? cropped = null;
-                if (viewModel.CroppedPictureFile is { Length: > 0 } croppedFile)
-                {
-                    cropped = new ImageFileInput(croppedFile.Length, croppedFile.ContentType,
-                        croppedFile.FileName, nameof(viewModel.CroppedPictureFile));
-                }
-
+            byte[]? newCroppedImageData = null;
+            if (original != null || cropped != null)
+            {
                 var validationErrors = imageValidationService.ValidateImagePair(original, cropped);
                 foreach (var error in validationErrors)
                 {
@@ -223,19 +228,22 @@ namespace QuestBoard.Service.Controllers.Contacts
                     viewModel.CanManage = true;
                     return View(viewModel);
                 }
+            }
 
+            if (hasNewOriginalUpload)
+            {
                 using var memoryStream = new MemoryStream();
-                await newContactImageFile.CopyToAsync(memoryStream, token);
+                await viewModel.ContactImageFile!.CopyToAsync(memoryStream, token);
                 existingContact.ContactImageData = memoryStream.ToArray();
-
-                if (cropped != null)
-                {
-                    using var croppedStream = new MemoryStream();
-                    await viewModel.CroppedPictureFile!.CopyToAsync(croppedStream, token);
-                    newCroppedImageData = croppedStream.ToArray();
-                }
             }
             // Otherwise, the contact image remains unchanged.
+
+            if (cropped != null)
+            {
+                using var croppedStream = new MemoryStream();
+                await viewModel.CroppedPictureFile!.CopyToAsync(croppedStream, token);
+                newCroppedImageData = croppedStream.ToArray();
+            }
 
             // Passing hasNewOriginalUpload lets the service clear any stale cropped image when a
             // genuinely new original arrives, while preserving it on an edit that doesn't touch

--- a/QuestBoard.Service/Controllers/DungeonMaster/DungeonMasterController.cs
+++ b/QuestBoard.Service/Controllers/DungeonMaster/DungeonMasterController.cs
@@ -108,18 +108,22 @@ public class DungeonMasterController(
         byte[]? imageBytes = null;
         byte[]? newCroppedImageData = null;
         var newProfilePictureFile = viewModel.ProfilePictureFile;
-        if (newProfilePictureFile != null && newProfilePictureFile.Length > 0)
+        var hasNewOriginalUpload = newProfilePictureFile != null && newProfilePictureFile.Length > 0;
+
+        ImageFileInput? original = hasNewOriginalUpload
+            ? new ImageFileInput(newProfilePictureFile!.Length, newProfilePictureFile.ContentType,
+                newProfilePictureFile.FileName, nameof(viewModel.ProfilePictureFile))
+            : null;
+
+        ImageFileInput? cropped = null;
+        if (viewModel.CroppedPictureFile is { Length: > 0 } croppedFile)
         {
-            var original = new ImageFileInput(newProfilePictureFile.Length, newProfilePictureFile.ContentType,
-                newProfilePictureFile.FileName, nameof(viewModel.ProfilePictureFile));
+            cropped = new ImageFileInput(croppedFile.Length, croppedFile.ContentType,
+                croppedFile.FileName, nameof(viewModel.CroppedPictureFile));
+        }
 
-            ImageFileInput? cropped = null;
-            if (viewModel.CroppedPictureFile is { Length: > 0 } croppedFile)
-            {
-                cropped = new ImageFileInput(croppedFile.Length, croppedFile.ContentType,
-                    croppedFile.FileName, nameof(viewModel.CroppedPictureFile));
-            }
-
+        if (original != null || cropped != null)
+        {
             var validationErrors = imageValidationService.ValidateImagePair(original, cropped);
             foreach (var error in validationErrors)
             {
@@ -129,17 +133,20 @@ public class DungeonMasterController(
             {
                 return View(viewModel);
             }
+        }
 
+        if (hasNewOriginalUpload)
+        {
             using var memoryStream = new MemoryStream();
-            await newProfilePictureFile.CopyToAsync(memoryStream, token);
+            await newProfilePictureFile!.CopyToAsync(memoryStream, token);
             imageBytes = memoryStream.ToArray();
+        }
 
-            if (cropped != null)
-            {
-                using var croppedStream = new MemoryStream();
-                await viewModel.CroppedPictureFile!.CopyToAsync(croppedStream, token);
-                newCroppedImageData = croppedStream.ToArray();
-            }
+        if (cropped != null)
+        {
+            using var croppedStream = new MemoryStream();
+            await viewModel.CroppedPictureFile!.CopyToAsync(croppedStream, token);
+            newCroppedImageData = croppedStream.ToArray();
         }
 
         await dmProfileService.UpsertProfileAsync(targetUser.Id, viewModel.Bio, imageBytes, newCroppedImageData: newCroppedImageData, token: token);
@@ -153,6 +160,23 @@ public class DungeonMasterController(
         if (!await IsTargetInActiveGroupAsync(id)) return NotFound();
 
         var bytes = await dmProfileService.GetCroppedPictureAsync(id, token);
+        if (bytes == null || bytes.Length == 0) return NotFound();
+
+        var contentType = bytes.Length >= 4 && bytes[0] == 0x89 && bytes[1] == 0x50
+            ? "image/png"
+            : bytes.Length >= 6 && bytes[0] == 0x47 && bytes[1] == 0x49 && bytes[2] == 0x46
+            ? "image/gif"
+            : "image/jpeg";
+
+        return File(bytes, contentType);
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetOriginalDMProfilePicture(int id, CancellationToken token = default)
+    {
+        if (!await IsTargetInActiveGroupAsync(id)) return NotFound();
+
+        var bytes = await dmProfileService.GetProfilePictureAsync(id, token);
         if (bytes == null || bytes.Length == 0) return NotFound();
 
         var contentType = bytes.Length >= 4 && bytes[0] == 0x89 && bytes[1] == 0x50

--- a/QuestBoard.Service/Views/Characters/Edit.Mobile.cshtml
+++ b/QuestBoard.Service/Views/Characters/Edit.Mobile.cshtml
@@ -26,6 +26,11 @@
                 {
                     <div class="mb-2 text-center">
                         <img src="@Url.Action("GetCroppedPicture", new { id = Model.Id })" alt="Current" class="img-thumbnail" style="max-width: 200px;" />
+                        <div>
+                            <button type="button" class="btn btn-sm btn-warning mt-2" id="recropPhotoBtn">
+                                <i class="fas fa-crop-alt me-1"></i>Re-crop Photo
+                            </button>
+                        </div>
                     </div>
                 }
                 <input type="file" asp-for="ProfilePictureFile" class="form-control" accept="image/*" id="profilePictureInput" />
@@ -230,6 +235,6 @@
             crossorigin="anonymous"></script>
     <script src="~/js/image-crop.js" asp-append-version="true"></script>
     <script>
-        initImageCrop({ fileInputId: 'profilePictureInput', hiddenCroppedInputName: 'CroppedPictureFile', aspectRatio: 1 });
+        initImageCrop({ fileInputId: 'profilePictureInput', hiddenCroppedInputName: 'CroppedPictureFile', aspectRatio: 1, recropButtonId: 'recropPhotoBtn', originalImageUrl: '@Url.Action("GetProfilePicture", new { id = Model.Id })' });
     </script>
 }

--- a/QuestBoard.Service/Views/Characters/Edit.cshtml
+++ b/QuestBoard.Service/Views/Characters/Edit.cshtml
@@ -29,6 +29,11 @@
                         {
                             <div class="mb-2">
                                 <img src="@Url.Action("GetCroppedPicture", new { id = Model.Id })" alt="Current" class="img-thumbnail" style="max-width: 200px;" />
+                                <div>
+                                    <button type="button" class="btn btn-sm btn-warning mt-2" id="recropPhotoBtn">
+                                        <i class="fas fa-crop-alt me-1"></i>Re-crop Photo
+                                    </button>
+                                </div>
                             </div>
                         }
                         <input type="file" asp-for="ProfilePictureFile" class="form-control" accept="image/*" id="profilePictureInput" />
@@ -241,6 +246,6 @@
             crossorigin="anonymous"></script>
     <script src="~/js/image-crop.js" asp-append-version="true"></script>
     <script>
-        initImageCrop({ fileInputId: 'profilePictureInput', hiddenCroppedInputName: 'CroppedPictureFile', aspectRatio: 1 });
+        initImageCrop({ fileInputId: 'profilePictureInput', hiddenCroppedInputName: 'CroppedPictureFile', aspectRatio: 1, recropButtonId: 'recropPhotoBtn', originalImageUrl: '@Url.Action("GetProfilePicture", new { id = Model.Id })' });
     </script>
 }

--- a/QuestBoard.Service/Views/Contacts/Edit.Mobile.cshtml
+++ b/QuestBoard.Service/Views/Contacts/Edit.Mobile.cshtml
@@ -24,6 +24,11 @@
                 {
                     <div class="mb-2 text-center">
                         <img src="@Url.Action("GetCroppedContactImage", new { id = Model.Id })" alt="Current" class="img-thumbnail" style="max-width: 200px;" />
+                        <div>
+                            <button type="button" class="btn btn-sm btn-warning mt-2" id="recropPhotoBtn">
+                                <i class="fas fa-crop-alt me-1"></i>Re-crop Photo
+                            </button>
+                        </div>
                     </div>
                 }
                 <input type="file" asp-for="ContactImageFile" class="form-control" accept="image/*" id="contactImageInput" />
@@ -128,6 +133,6 @@
             crossorigin="anonymous"></script>
     <script src="~/js/image-crop.js" asp-append-version="true"></script>
     <script>
-        initImageCrop({ fileInputId: 'contactImageInput', hiddenCroppedInputName: 'CroppedPictureFile', aspectRatio: 1 });
+        initImageCrop({ fileInputId: 'contactImageInput', hiddenCroppedInputName: 'CroppedPictureFile', aspectRatio: 1, recropButtonId: 'recropPhotoBtn', originalImageUrl: '@Url.Action("GetContactImage", new { id = Model.Id })' });
     </script>
 }

--- a/QuestBoard.Service/Views/Contacts/Edit.cshtml
+++ b/QuestBoard.Service/Views/Contacts/Edit.cshtml
@@ -26,6 +26,11 @@
                         {
                             <div class="mb-2">
                                 <img src="@Url.Action("GetCroppedContactImage", new { id = Model.Id })" alt="Current" class="img-thumbnail" style="max-width: 200px;" />
+                                <div>
+                                    <button type="button" class="btn btn-sm btn-warning mt-2" id="recropPhotoBtn">
+                                        <i class="fas fa-crop-alt me-1"></i>Re-crop Photo
+                                    </button>
+                                </div>
                             </div>
                         }
                         <input type="file" asp-for="ContactImageFile" class="form-control" accept="image/*" id="contactImageInput" />
@@ -137,6 +142,6 @@
             crossorigin="anonymous"></script>
     <script src="~/js/image-crop.js" asp-append-version="true"></script>
     <script>
-        initImageCrop({ fileInputId: 'contactImageInput', hiddenCroppedInputName: 'CroppedPictureFile', aspectRatio: 1 });
+        initImageCrop({ fileInputId: 'contactImageInput', hiddenCroppedInputName: 'CroppedPictureFile', aspectRatio: 1, recropButtonId: 'recropPhotoBtn', originalImageUrl: '@Url.Action("GetContactImage", new { id = Model.Id })' });
     </script>
 }

--- a/QuestBoard.Service/Views/DungeonMaster/EditProfile.Mobile.cshtml
+++ b/QuestBoard.Service/Views/DungeonMaster/EditProfile.Mobile.cshtml
@@ -33,6 +33,11 @@
                         <img src="@Url.Action("GetDMProfilePicture", new { id = Model.DungeonMasterId })"
                              alt="Current profile photo"
                              class="dm-profile-photo" />
+                        <div>
+                            <button type="button" class="btn btn-sm btn-warning mt-2" id="recropPhotoBtn">
+                                <i class="fas fa-crop-alt me-1"></i>Re-crop Photo
+                            </button>
+                        </div>
                     </div>
                 }
                 <input type="file" asp-for="ProfilePictureFile"
@@ -124,6 +129,6 @@
             crossorigin="anonymous"></script>
     <script src="~/js/image-crop.js" asp-append-version="true"></script>
     <script>
-        initImageCrop({ fileInputId: 'dmProfilePictureInput', hiddenCroppedInputName: 'CroppedPictureFile', aspectRatio: 1 });
+        initImageCrop({ fileInputId: 'dmProfilePictureInput', hiddenCroppedInputName: 'CroppedPictureFile', aspectRatio: 1, recropButtonId: 'recropPhotoBtn', originalImageUrl: '@Url.Action("GetOriginalDMProfilePicture", new { id = Model.DungeonMasterId })' });
     </script>
 }

--- a/QuestBoard.Service/Views/DungeonMaster/EditProfile.cshtml
+++ b/QuestBoard.Service/Views/DungeonMaster/EditProfile.cshtml
@@ -30,6 +30,11 @@
                                         <img src="@Url.Action("GetDMProfilePicture", new { id = Model.DungeonMasterId })"
                                              alt="Current profile photo"
                                              class="rounded-circle dm-profile-photo" />
+                                        <div>
+                                            <button type="button" class="btn btn-sm btn-warning mt-2" id="recropPhotoBtn">
+                                                <i class="fas fa-crop-alt me-1"></i>Re-crop Photo
+                                            </button>
+                                        </div>
                                     </div>
                                 }
                                 <input type="file" asp-for="ProfilePictureFile"
@@ -130,6 +135,6 @@
             crossorigin="anonymous"></script>
     <script src="~/js/image-crop.js" asp-append-version="true"></script>
     <script>
-        initImageCrop({ fileInputId: 'dmProfilePictureInput', hiddenCroppedInputName: 'CroppedPictureFile', aspectRatio: 1 });
+        initImageCrop({ fileInputId: 'dmProfilePictureInput', hiddenCroppedInputName: 'CroppedPictureFile', aspectRatio: 1, recropButtonId: 'recropPhotoBtn', originalImageUrl: '@Url.Action("GetOriginalDMProfilePicture", new { id = Model.DungeonMasterId })' });
     </script>
 }

--- a/QuestBoard.Service/wwwroot/js/image-crop.js
+++ b/QuestBoard.Service/wwwroot/js/image-crop.js
@@ -86,9 +86,14 @@ function initImageCrop(config) {
     // (and already drifted) across every upload view's own inline <script>.
     const maxFileSizeBytes = config.maxFileSizeBytes || (5 * 1024 * 1024);
     const allowedTypes = config.allowedTypes || ['image/jpeg', 'image/jpg', 'image/png', 'image/gif'];
+    // Optional re-crop trigger: reopens the shared crop modal against the already-stored
+    // original image (fetched from originalImageUrl) instead of a freshly-picked File.
+    const recropButtonId = config.recropButtonId;
+    const originalImageUrl = config.originalImageUrl;
 
     const fileInput = fileInputId ? document.getElementById(fileInputId) : null;
-    if (!fileInput) {
+    const recropBtn = recropButtonId ? document.getElementById(recropButtonId) : null;
+    if (!fileInput && !recropBtn) {
         // Nothing to wire on this page -- safe no-op so the same script can be included
         // defensively without checking which view is currently rendered.
         return;
@@ -166,49 +171,11 @@ function initImageCrop(config) {
         hiddenInput.files = dt.files;
     }
 
-    fileInput.addEventListener('change', async function (e) {
-        const file = e.target.files && e.target.files[0];
-        if (!file) {
-            return;
-        }
-
-        clearReadError();
-
-        if (file.size > maxFileSizeBytes) {
-            const sizeMB = (file.size / 1024 / 1024).toFixed(2);
-            const maxMB = (maxFileSizeBytes / 1024 / 1024).toFixed(0);
-            showError('File size (' + sizeMB + ' MB) exceeds the maximum allowed size of ' + maxMB + ' MB. Please choose a smaller image.');
-            fileInput.value = '';
-            return;
-        }
-
-        if (!allowedTypes.includes(file.type)) {
-            showError('Only image files (JPG, PNG, GIF) are allowed.');
-            fileInput.value = '';
-            return;
-        }
-
-        if (file.type === 'image/gif') {
-            // Cropper.js always re-encodes the crop selection as a static JPEG (extractCroppedBlob),
-            // which would silently strip an animated GIF's animation everywhere the cropped image is
-            // displayed. Skip the crop flow entirely for GIFs -- the original file submits as-is via
-            // the visible file input, and the server-side dual-image fallback (CroppedImageData ??
-            // OriginalImageData) displays the original animated GIF everywhere since no crop is saved.
-            resetCropState();
-            return;
-        }
-
-        currentOriginalFileName = file.name || 'photo';
-
-        let correctedBlob;
-        try {
-            correctedBlob = await prepareImageForCropper(file, 2400);
-        } catch (err) {
-            showReadError();
-            fileInput.value = '';
-            return;
-        }
-
+    // Opens the crop modal against an already-prepared (decoded, downscaled) blob -- shared by
+    // the file-input change handler (a freshly picked File) and the re-crop trigger (a File
+    // fetched from the stored original), so the modal-open/auto-fit/hidden-input-populate
+    // sequence only lives in one place.
+    async function openCropperWithPreparedBlob(correctedBlob) {
         revokeCurrentObjectUrl();
         currentObjectUrl = URL.createObjectURL(correctedBlob);
         cropperImageEl.src = currentObjectUrl;
@@ -245,7 +212,96 @@ function initImageCrop(config) {
             });
         }
         modal.show();
-    });
+    }
+
+    if (fileInput) {
+        fileInput.addEventListener('change', async function (e) {
+            const file = e.target.files && e.target.files[0];
+            if (!file) {
+                return;
+            }
+
+            clearReadError();
+
+            if (file.size > maxFileSizeBytes) {
+                const sizeMB = (file.size / 1024 / 1024).toFixed(2);
+                const maxMB = (maxFileSizeBytes / 1024 / 1024).toFixed(0);
+                showError('File size (' + sizeMB + ' MB) exceeds the maximum allowed size of ' + maxMB + ' MB. Please choose a smaller image.');
+                fileInput.value = '';
+                return;
+            }
+
+            if (!allowedTypes.includes(file.type)) {
+                showError('Only image files (JPG, PNG, GIF) are allowed.');
+                fileInput.value = '';
+                return;
+            }
+
+            if (file.type === 'image/gif') {
+                // Cropper.js always re-encodes the crop selection as a static JPEG (extractCroppedBlob),
+                // which would silently strip an animated GIF's animation everywhere the cropped image is
+                // displayed. Skip the crop flow entirely for GIFs -- the original file submits as-is via
+                // the visible file input, and the server-side dual-image fallback (CroppedImageData ??
+                // OriginalImageData) displays the original animated GIF everywhere since no crop is saved.
+                resetCropState();
+                return;
+            }
+
+            currentOriginalFileName = file.name || 'photo';
+
+            let correctedBlob;
+            try {
+                correctedBlob = await prepareImageForCropper(file, 2400);
+            } catch (err) {
+                showReadError();
+                fileInput.value = '';
+                return;
+            }
+
+            await openCropperWithPreparedBlob(correctedBlob);
+        });
+    }
+
+    if (recropBtn) {
+        recropBtn.addEventListener('click', async function () {
+            clearReadError();
+
+            let response;
+            try {
+                response = await fetch(originalImageUrl, { cache: 'no-store' });
+            } catch (err) {
+                showReadError();
+                return;
+            }
+
+            if (!response.ok) {
+                showReadError();
+                return;
+            }
+
+            const contentType = response.headers.get('Content-Type') || '';
+            if (contentType.indexOf('image/gif') !== -1) {
+                // Mirrors the upload-path GIF skip above -- cropping always re-encodes to a
+                // static JPEG, which would silently strip the stored original's animation.
+                showError("This photo is an animated GIF and can't be re-cropped without losing its animation.");
+                return;
+            }
+
+            const blob = await response.blob();
+            const originalFile = new File([blob], 'photo', { type: contentType });
+            currentOriginalFileName = 'photo';
+
+            let correctedBlob;
+            try {
+                correctedBlob = await prepareImageForCropper(originalFile, 2400);
+            } catch (err) {
+                showReadError();
+                return;
+            }
+
+            await openCropperWithPreparedBlob(correctedBlob);
+        });
+    }
 
     if (confirmBtn) {
         confirmBtn.addEventListener('click', async function () {
@@ -263,7 +319,9 @@ function initImageCrop(config) {
 
     if (cancelBtn) {
         cancelBtn.addEventListener('click', function () {
-            fileInput.value = '';
+            if (fileInput) {
+                fileInput.value = '';
+            }
             resetCropState();
         });
     }

--- a/QuestBoard.UnitTests/Services/CharacterServiceTests.cs
+++ b/QuestBoard.UnitTests/Services/CharacterServiceTests.cs
@@ -201,6 +201,33 @@ public class CharacterServiceTests
     }
 
     [Fact]
+    public async Task UpdateAsync_CropOnlyNoNewOriginal_PersistsCropAndPreservesOriginal()
+    {
+        // Arrange: seed a character with original A + crop A
+        var groupContext = new MutableTestGroupContext { ActiveGroupId = null };
+        await using var context = CreateContext("CharacterServiceTests." + nameof(UpdateAsync_CropOnlyNoNewOriginal_PersistsCropAndPreservesOriginal), groupContext);
+        await SeedCharacterWithImagesAsync(context, groupContext, [1, 2, 3], [9, 9, 9]);
+
+        var mapper = CreateMapper();
+        var repository = new CharacterRepository(context, mapper);
+        var service = new CharacterService(repository, mapper);
+        groupContext.ActiveGroupId = 1;
+
+        var character = await repository.GetCharacterWithDetailsAsync(1, TestContext.Current.CancellationToken);
+        character.Should().NotBeNull();
+        character!.ProfilePicture = null; // round-tripped value on a no-photo-change edit
+
+        // Act: re-crop of the already-stored original -- no new original uploaded this request
+        await service.UpdateAsync(character, hasNewOriginalUpload: false, newCroppedImageData: [200, 201, 202], TestContext.Current.CancellationToken);
+
+        // Assert: the new crop is persisted AND the stored original is preserved
+        var original = await repository.GetCharacterOriginalPictureAsync(1, TestContext.Current.CancellationToken);
+        var cropped = await repository.GetCharacterCroppedPictureAsync(1, TestContext.Current.CancellationToken);
+        original.Should().Equal([1, 2, 3]);
+        cropped.Should().Equal([200, 201, 202]);
+    }
+
+    [Fact]
     public async Task AddAsync_NewCropSupplied_PersistsCrop()
     {
         // Arrange: a fresh group/owner, no character yet

--- a/QuestBoard.UnitTests/Services/ContactServiceTests.cs
+++ b/QuestBoard.UnitTests/Services/ContactServiceTests.cs
@@ -198,6 +198,33 @@ public class ContactServiceTests
     }
 
     [Fact]
+    public async Task UpdateAsync_CropOnlyNoNewOriginal_PersistsCropAndPreservesOriginal()
+    {
+        // Arrange: seed a contact with original A + crop A
+        var groupContext = new MutableTestGroupContext { ActiveGroupId = null };
+        await using var context = CreateContext("ContactServiceTests." + nameof(UpdateAsync_CropOnlyNoNewOriginal_PersistsCropAndPreservesOriginal), groupContext);
+        await SeedContactWithImagesAsync(context, groupContext, [1, 2, 3], [9, 9, 9]);
+
+        var mapper = CreateMapper();
+        var repository = new ContactRepository(context, mapper);
+        var service = new ContactService(repository, mapper);
+        groupContext.ActiveGroupId = 1;
+
+        var contact = await repository.GetContactWithDetailsAsync(1, TestContext.Current.CancellationToken);
+        contact.Should().NotBeNull();
+        contact!.ContactImageData = null; // round-tripped value on a no-photo-change edit
+
+        // Act: re-crop of the already-stored original -- no new original uploaded this request
+        await service.UpdateAsync(contact, hasNewOriginalUpload: false, newCroppedImageData: [200, 201, 202], TestContext.Current.CancellationToken);
+
+        // Assert: the new crop is persisted AND the stored original is preserved
+        var original = await repository.GetContactOriginalImageAsync(1, TestContext.Current.CancellationToken);
+        var cropped = await repository.GetContactCroppedImageAsync(1, TestContext.Current.CancellationToken);
+        original.Should().Equal([1, 2, 3]);
+        cropped.Should().Equal([200, 201, 202]);
+    }
+
+    [Fact]
     public async Task AddAsync_NewCropSupplied_PersistsCrop()
     {
         // Arrange: a fresh group/creator, no contact yet

--- a/QuestBoard.UnitTests/Services/DungeonMasterProfileServiceTests.cs
+++ b/QuestBoard.UnitTests/Services/DungeonMasterProfileServiceTests.cs
@@ -128,6 +128,29 @@ public class DungeonMasterProfileServiceTests
         cropped.Should().Equal([70, 71, 72]);
     }
 
+    [Fact]
+    public async Task UpsertProfileAsync_CropOnlyNoNewOriginal_PersistsCropAndPreservesOriginal()
+    {
+        // Arrange: seed a DM profile with original A + crop A
+        var groupContext = new MutableTestGroupContext { ActiveGroupId = 1 };
+        await using var context = CreateContext(nameof(UpsertProfileAsync_CropOnlyNoNewOriginal_PersistsCropAndPreservesOriginal), groupContext);
+        await SeedDungeonMasterProfileWithImagesAsync(context, 1, [1, 2, 3], [9, 9, 9]);
+
+        var mapper = CreateMapper();
+        var repository = new DungeonMasterProfileRepository(context, mapper);
+        var service = new DungeonMasterProfileService(repository, mapper);
+
+        // Act: re-crop of the already-stored original -- no new original uploaded, no removal
+        await service.UpsertProfileAsync(1, "Original bio.", imageBytes: null, removeImage: false, newCroppedImageData: [200, 201, 202], token: TestContext.Current.CancellationToken);
+
+        // Assert: the new crop is persisted AND the stored original is preserved, not wiped to
+        // null -- ApplyProfileImage treats a null original as "delete the whole image".
+        var cropped = await repository.GetCroppedPictureAsync(1, TestContext.Current.CancellationToken);
+        var original = await repository.GetOriginalPictureAsync(1, TestContext.Current.CancellationToken);
+        cropped.Should().Equal([200, 201, 202]);
+        original.Should().Equal([1, 2, 3]);
+    }
+
     private sealed class MutableTestGroupContext : IActiveGroupContext
     {
         public int? ActiveGroupId { get; set; }


### PR DESCRIPTION
## Summary

Photos can be uploaded in 3 places (Character, Contact, DM Profile), each already storing a separate Original + Cropped image. The intent was to let a user re-open the cropper against an already-stored photo without re-uploading a file, but no trigger for that existed — and three backend codepaths would have silently dropped, or in DM Profile's case actually **deleted**, a crop-only submission.

- Added a "Re-crop Photo" button to all 6 Edit views (Character, Contact, DM Profile — desktop + mobile), gated on an existing photo. It loads the stored **original** (not the already-cropped square) into the shared Cropper.js modal, so a bad first crop can still be corrected without permanently losing the cut-off parts of the photo.
- Fixed `DungeonMasterProfileService.UpsertProfileAsync`: it previously ignored a crop-only submission for the `updateImage` gate, and the repository treats a null original as "delete the whole image" — so wiring this naively would have wiped the DM's stored photo. It now re-fetches the existing original before writing.
- Added the missing `GetOriginalDMProfilePicture` endpoint (DM Profile had no way to expose its original image), guarded identically to the existing `GetDMProfilePicture`.
- Restructured `CharactersController.Edit` / `ContactsController.Edit` to read, validate, and persist `CroppedPictureFile` regardless of whether a new original was also uploaded — the service layer already supported this independently, only the controllers were gating it away.
- Extended `image-crop.js` with a shared re-crop trigger that fetches the stored original and refuses to open the modal for an animated GIF (mirrors the existing upload-path GIF skip, so a stored GIF is never silently flattened to a static JPEG).

## Test plan

- [x] `dotnet build QuestBoard.slnx` — 0 errors, 0 warnings
- [x] Unit tests: 305/305 passing, including new crop-only tests for Character, Contact, and DM Profile (the DM test explicitly asserts the original is preserved, not wiped)
- [x] Integration tests: 399/399 passing, including new crop-only POST tests for all 3 controllers
- [x] Manually verified in a live browser session: Character re-crop (confirmed it fetches `GetProfilePicture`, adjusts crop, saves, and the new crop renders), DM Profile re-crop (confirmed it fetches the new `GetOriginalDMProfilePicture` endpoint, saves, and the photo is **not wiped**), and Contacts correctly hides the button when no photo exists
- [x] No EF migration needed — wires existing Original/Cropped columns through new codepaths only

🤖 Generated with [Claude Code](https://claude.com/claude-code)