### PR TITLE
Fix waitlist No-vote auto-promotion bug; add waitlist section to Quest Manage

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -31,7 +31,7 @@ See: .planning/PROJECT.md (updated 2026-07-11 — v8.0 milestone close)
 Phase: None (between milestones)
 Plan: None
 Status: v8.0 shipped; no active milestone
-Last activity: 2026-07-13 - Completed quick task 260713-js8: Add re-crop trigger for existing profile images (Characters, Contacts, DM Profile) and fix backend gaps that would drop or wipe crop-only submissions
+Last activity: 2026-07-14 - Completed quick task 260714-b0w: Waitlist table missing on quest details/manage pages when quest is finalized, or 'No' votes not showing in waitlist
 
 Progress: [██████████] 100% (v8.0, 7/7 phases)
 
@@ -74,6 +74,7 @@ None open for v8.0. Carried forward from prior milestones, still unresolved:
 | # | Description | Date | Commit | Directory |
 |---|-------------|------|--------|-----------|
 | 260713-js8 | Add re-crop trigger for existing profile images (Characters, Contacts, DM Profile) and fix backend gaps that would drop or wipe crop-only submissions | 2026-07-13 | d2f2f95 | [260713-js8-add-re-crop-trigger-for-existing-profile](./quick/260713-js8-add-re-crop-trigger-for-existing-profile/) |
+| 260714-b0w | Waitlist table missing on quest details/manage pages when quest is finalized, or 'No' votes not showing in waitlist | 2026-07-14 | 79e76cb | [260714-b0w-waitlist-table-missing-on-quest-details-](./quick/260714-b0w-waitlist-table-missing-on-quest-details-/) |
 
 ## Deferred Items
 

--- a/.planning/quick/260714-b0w-waitlist-table-missing-on-quest-details-/260714-b0w-PLAN.md
+++ b/.planning/quick/260714-b0w-waitlist-table-missing-on-quest-details-/260714-b0w-PLAN.md
@@ -7,6 +7,8 @@ depends_on: []
 files_modified:
   - QuestBoard.Repository/PlayerSignupRepository.cs
   - QuestBoard.UnitTests/Repository/PlayerSignupRepositoryTests.cs
+  - QuestBoard.Service/Views/Quest/Manage.cshtml
+  - QuestBoard.Service/Views/Quest/Manage.Mobile.cshtml
 autonomous: true
 requirements: [quick-260714-b0w]
 
@@ -15,21 +17,29 @@ must_haves:
     - "When a seat frees on a finalized quest, only a waitlisted player who voted Yes or Maybe for the finalized date is auto-promoted into the participant list."
     - "A player who voted No (or never voted) for the finalized date is never auto-promoted; they remain on the waitlist and are still displayed there."
     - "The Selected Participants list on both Quest Details and Quest Manage no longer includes players whose finalized-date vote is No."
+    - "The Quest Manage page (desktop and mobile) shows a Waitlist section for finalized quests, listing non-selected Player-role signups with their vote (Yes/Maybe/No/No Vote), so a DM can see who voted No."
   artifacts:
     - QuestBoard.Repository/PlayerSignupRepository.cs
     - QuestBoard.UnitTests/Repository/PlayerSignupRepositoryTests.cs
+    - QuestBoard.Service/Views/Quest/Manage.cshtml
+    - QuestBoard.Service/Views/Quest/Manage.Mobile.cshtml
   key_links:
     - "GetTopWaitlistedCandidateAsync (promotion eligibility) → PromoteNextWaitlistedPlayerIfSeatFreedAsync (sets IsSelected) → IsSelected drives the participant/waitlist split in both views."
+    - "Details.cshtml/Details.Mobile.cshtml waitlist table pattern (Model.Quest.PlayerSignups, !IsSelected && Role==Player, OrderWaitlist) → mirrored onto Manage.cshtml/Manage.Mobile.cshtml (Model.PlayerSignups, same filter/order, no ViewModel or query changes needed)."
 ---
 
 <objective>
 Fix the regression where players who voted "No" (or did not vote) for a finalized quest's
 date end up in the "Selected Participants" list, counting against the quest's player capacity,
-instead of staying on the waitlist.
+instead of staying on the waitlist. Additionally, add a Waitlist section to the Quest Manage
+page (desktop + mobile) so DMs can see who is waitlisted — including who voted No — while
+managing a finalized quest, matching what already exists on Quest Details.
 
 Purpose: Restore the intended separation — confirmed-available players (Yes/Maybe) are
-participants; unavailable/No/non-voting players stay on the waitlist and remain visible there.
-Output: A one-line eligibility filter in the waitlist auto-promotion query, plus regression tests.
+participants; unavailable/No/non-voting players stay on the waitlist and remain visible there,
+on both the player-facing Details page and the DM-facing Manage page.
+Output: A one-line eligibility filter in the waitlist auto-promotion query, regression tests,
+and a Waitlist table/card-list added to Manage.cshtml and Manage.Mobile.cshtml.
 </objective>
 
 <root_cause>
@@ -42,7 +52,9 @@ The bug is NOT in the view markup and NOT a removed waitlist table:
 - The Quest Manage page (`Views/Quest/Manage.cshtml`) never had a waitlist table
   (`git log -S "Waitlist"` on that file is empty); its finalized view only shows "Selected
   Participants". So the "table removed on Manage" symptom is really No-voters contaminating
-  the Selected Participants list.
+  the Selected Participants list. Per user feedback, a waitlist section is still wanted on
+  Manage — DMs benefit from seeing who voted No while managing a finalized quest — so this plan
+  adds one (Task 3) in addition to fixing the promotion bug.
 
 The true root cause is the post-finalization waitlist auto-promotion added in Phase 44:
 
@@ -78,6 +90,10 @@ an open seat; only a No vote never grants a seat" — `QuestService.ChangeVoteAs
 @QuestBoard.Domain/Extensions/WaitlistOrdering.cs
 @QuestBoard.Domain/Enums/VoteType.cs
 @QuestBoard.UnitTests/Repository/PlayerSignupRepositoryTests.cs
+@QuestBoard.Service/Views/Quest/Details.cshtml
+@QuestBoard.Service/Views/Quest/Details.Mobile.cshtml
+@QuestBoard.Service/Views/Quest/Manage.cshtml
+@QuestBoard.Service/Views/Quest/Manage.Mobile.cshtml
 </context>
 
 <tasks>
@@ -151,6 +167,172 @@ an open seat; only a No vote never grants a seat" — `QuestService.ChangeVoteAs
   </done>
 </task>
 
+<task type="auto">
+  <name>Task 3: Add Waitlist section to Quest Manage page (desktop + mobile)</name>
+  <files>QuestBoard.Service/Views/Quest/Manage.cshtml, QuestBoard.Service/Views/Quest/Manage.Mobile.cshtml</files>
+  <action>
+    Manage.cshtml (`@model Quest`) currently has NO waitlist table — only "Selected Participants".
+    `Model.PlayerSignups` already contains ALL signups (selected and waitlisted) with `.Player`,
+    `.DateVotes`, `.Character` loaded (same repository projection as Details.cshtml), so this is a
+    pure Razor markup addition — no controller, repository, or ViewModel change.
+
+    Both files are missing `@using QuestBoard.Domain.Extensions` (needed for the `OrderWaitlist`
+    extension method used by Details.cshtml/Details.Mobile.cshtml). Add it to the `@using` block
+    at the top of both files.
+
+    **Manage.cshtml**: Insert a new block immediately after the `}` that closes the
+    `@if (allSelectedParticipants.Any()) { ... } else { <p class="text-muted">No participants
+    selected for this quest.</p> }` block, and before the `<hr>` that precedes the action-buttons
+    `<div class="d-flex justify-content-between align-items-center">`. This keeps the waitlist
+    visible even when there are zero selected participants. Insert exactly:
+    ```razor
+    @{
+        var waitlistFinalizedProposedDateManage = Model.ProposedDates?.FirstOrDefault(pd => pd.Date == Model.FinalizedDate);
+        var waitlistPlayersManage = waitlistFinalizedProposedDateManage != null
+            ? Model.PlayerSignups.Where(ps => !ps.IsSelected && ps.Role == SignupRole.Player).OrderWaitlist(waitlistFinalizedProposedDateManage.Id).ToList()
+            : Model.PlayerSignups.Where(ps => !ps.IsSelected && ps.Role == SignupRole.Player).OrderBy(ps => ps.SignupTime).ToList();
+    }
+    @if (waitlistPlayersManage.Any())
+    {
+        <h6>Waitlist:</h6>
+        <div class="table-responsive">
+            <table class="table table-striped table-hover">
+                <thead>
+                    <tr>
+                        <th>Player Name</th>
+                        <th>Character</th>
+                        <th>Role</th>
+                        <th>Vote</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var player in waitlistPlayersManage)
+                    {
+                        var waitlistPlayerVoteManage = player.DateVotes
+                            ?.FirstOrDefault(dv => dv.ProposedDateId == waitlistFinalizedProposedDateManage?.Id)?.Vote;
+                        <tr>
+                            <td>@player.Player.Name</td>
+                            <td>
+                                @if (player.Character != null)
+                                {
+                                    <div class="d-flex align-items-center">
+                                        <img src="@Url.Action("GetCroppedPicture", "Characters", new { id = player.Character.Id })"
+                                             alt="@player.Character.Name"
+                                             class="character-mini-avatar me-2"
+                                             style="width: 32px; height: 32px; border-radius: 50%; object-fit: cover;"
+                                             onerror="this.style.display='none'; this.nextElementSibling.style.display='inline-flex';" />
+                                        <span class="character-mini-avatar-placeholder me-2" style="width: 32px; height: 32px; display: none; align-items: center; justify-content: center; background-color: #6c757d; color: white; border-radius: 50%;">
+                                            <i class="fas fa-user"></i>
+                                        </span>
+                                        <span>@player.Character.Name</span>
+                                    </div>
+                                }
+                                else
+                                {
+                                    <span class="text-muted fst-italic">No character</span>
+                                }
+                            </td>
+                            <td>
+                                <span class="badge bg-secondary">
+                                    <i class="fas fa-user me-1"></i>Player (Waitlist)
+                                </span>
+                            </td>
+                            <td>
+                                @if (waitlistPlayerVoteManage == VoteType.Yes)
+                                {
+                                    <span class="badge bg-success">
+                                        <i class="fas fa-check me-1"></i>Yes
+                                    </span>
+                                }
+                                else if (waitlistPlayerVoteManage == VoteType.Maybe)
+                                {
+                                    <span class="badge bg-warning text-dark">
+                                        <i class="fas fa-question me-1"></i>Maybe
+                                    </span>
+                                }
+                                else if (waitlistPlayerVoteManage == VoteType.No)
+                                {
+                                    <span class="badge bg-danger">
+                                        <i class="fas fa-times me-1"></i>No
+                                    </span>
+                                }
+                                else
+                                {
+                                    <span class="badge bg-secondary">
+                                        <i class="fas fa-minus me-1"></i>No Vote
+                                    </span>
+                                }
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    }
+    ```
+
+    **Manage.Mobile.cshtml**: Insert an equivalent block immediately after the `}` that closes the
+    `@if (allSelectedParticipants.Any()) { ... } else { <p class="text-muted">No participants
+    selected for this quest.</p> }` block, and before the `<hr>` that precedes the action-buttons
+    `<div class="d-flex flex-wrap gap-2 mt-3">`. Mirror the card style already used by this file's
+    "Selected Participants" section and by `Details.Mobile.cshtml`'s waitlist cards:
+    ```razor
+    @{
+        var waitlistFinalizedProposedDateManage = Model.ProposedDates?.FirstOrDefault(pd => pd.Date == Model.FinalizedDate);
+        var waitlistPlayersManage = waitlistFinalizedProposedDateManage != null
+            ? Model.PlayerSignups.Where(ps => !ps.IsSelected && ps.Role == SignupRole.Player).OrderWaitlist(waitlistFinalizedProposedDateManage.Id).ToList()
+            : Model.PlayerSignups.Where(ps => !ps.IsSelected && ps.Role == SignupRole.Player).OrderBy(ps => ps.SignupTime).ToList();
+    }
+    @if (waitlistPlayersManage.Any())
+    {
+        <h6 class="dm-manage-subheading mb-2">Waitlist</h6>
+        @foreach (var player in waitlistPlayersManage)
+        {
+            var waitlistPlayerVoteManage = player.DateVotes
+                ?.FirstOrDefault(dv => dv.ProposedDateId == waitlistFinalizedProposedDateManage?.Id)?.Vote;
+            <div class="participant-row d-flex justify-content-between align-items-center py-2 border-bottom">
+                <div>
+                    <span class="fw-bold dm-manage-player-name">@player.Player.Name</span>
+                    <br>
+                    <small>@(player.Character?.Name ?? "No character")</small>
+                </div>
+                @if (waitlistPlayerVoteManage == VoteType.Yes)
+                {
+                    <span class="badge bg-success"><i class="fas fa-check me-1"></i>Yes</span>
+                }
+                else if (waitlistPlayerVoteManage == VoteType.Maybe)
+                {
+                    <span class="badge bg-warning text-dark"><i class="fas fa-question me-1"></i>Maybe</span>
+                }
+                else if (waitlistPlayerVoteManage == VoteType.No)
+                {
+                    <span class="badge bg-danger"><i class="fas fa-times me-1"></i>No</span>
+                }
+                else
+                {
+                    <span class="badge bg-secondary"><i class="fas fa-minus me-1"></i>No Vote</span>
+                }
+            </div>
+        }
+    }
+    ```
+
+    Do not touch the "Selected Participants" block, the action buttons, or any unfinalized-quest
+    markup in either file. Do not extract a shared partial — follow the codebase's existing
+    per-view duplication convention (same as Details.cshtml/Details.Mobile.cshtml).
+  </action>
+  <verify>
+    <automated>dotnet build QuestBoard.Service/QuestBoard.Service.csproj</automated>
+  </verify>
+  <done>
+    Both Manage.cshtml and Manage.Mobile.cshtml render a Waitlist section for finalized quests
+    when non-selected Player signups exist, showing each player's name, character, and vote
+    (including a red "No" badge); the section is absent when the waitlist is empty. Project
+    compiles. No changes to Details.cshtml, Details.Mobile.cshtml, controllers, repositories, or
+    ViewModels.
+  </done>
+</task>
+
 </tasks>
 
 <security_note>
@@ -166,16 +348,22 @@ so it carries no new STRIDE exposure. No threat register required for this quick
 - Manual sanity (optional, DM account): finalize a quest whose leftover waitlist is only No
   voters, then have a selected player vote No to free a seat — confirm no No voter is pulled into
   Selected Participants on either the Details or Manage page, and the No voters remain listed in
-  the Details waitlist table.
+  the Details waitlist table and the new Manage waitlist table.
+- Manual sanity: open Manage on a finalized quest that has at least one non-selected Player
+  signup — confirm the new Waitlist table (desktop) / card list (mobile) appears below Selected
+  Participants, showing the correct vote badge per player, and that it's absent when the
+  waitlist is empty.
 </verification>
 
 <success_criteria>
 - Waitlist auto-promotion only ever selects a player who voted Yes or Maybe for the finalized date.
-- No voters and non-voters stay on the waitlist (still shown in the Details waitlist table) and
-  never appear in the Selected Participants list on Details or Manage, nor count against
-  TotalPlayerCount.
-- No view files changed; both desktop and mobile views render correct data purely from the fixed
-  IsSelected state. All existing tests remain green.
+- No voters and non-voters stay on the waitlist (still shown on Details) and never appear in the
+  Selected Participants list on Details or Manage, nor count against TotalPlayerCount.
+- Quest Manage (desktop and mobile) now shows a Waitlist section for finalized quests, matching
+  the Details page pattern, so a DM can see who is waitlisted and how each waitlisted player
+  voted — including No voters.
+- No changes to Details.cshtml, Details.Mobile.cshtml, controllers, repositories, or ViewModels
+  beyond the promotion-eligibility fix in Task 1. All existing tests remain green.
 </success_criteria>
 
 <notes>

--- a/.planning/quick/260714-b0w-waitlist-table-missing-on-quest-details-/260714-b0w-PLAN.md
+++ b/.planning/quick/260714-b0w-waitlist-table-missing-on-quest-details-/260714-b0w-PLAN.md
@@ -1,0 +1,191 @@
+---
+phase: quick-260714-b0w
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - QuestBoard.Repository/PlayerSignupRepository.cs
+  - QuestBoard.UnitTests/Repository/PlayerSignupRepositoryTests.cs
+autonomous: true
+requirements: [quick-260714-b0w]
+
+must_haves:
+  truths:
+    - "When a seat frees on a finalized quest, only a waitlisted player who voted Yes or Maybe for the finalized date is auto-promoted into the participant list."
+    - "A player who voted No (or never voted) for the finalized date is never auto-promoted; they remain on the waitlist and are still displayed there."
+    - "The Selected Participants list on both Quest Details and Quest Manage no longer includes players whose finalized-date vote is No."
+  artifacts:
+    - QuestBoard.Repository/PlayerSignupRepository.cs
+    - QuestBoard.UnitTests/Repository/PlayerSignupRepositoryTests.cs
+  key_links:
+    - "GetTopWaitlistedCandidateAsync (promotion eligibility) → PromoteNextWaitlistedPlayerIfSeatFreedAsync (sets IsSelected) → IsSelected drives the participant/waitlist split in both views."
+---
+
+<objective>
+Fix the regression where players who voted "No" (or did not vote) for a finalized quest's
+date end up in the "Selected Participants" list, counting against the quest's player capacity,
+instead of staying on the waitlist.
+
+Purpose: Restore the intended separation — confirmed-available players (Yes/Maybe) are
+participants; unavailable/No/non-voting players stay on the waitlist and remain visible there.
+Output: A one-line eligibility filter in the waitlist auto-promotion query, plus regression tests.
+</objective>
+
+<root_cause>
+The bug is NOT in the view markup and NOT a removed waitlist table:
+
+- Both the Quest Details waitlist table (`Views/Quest/Details.cshtml` lines ~205-298) and the
+  participant/waitlist split are driven by `PlayerSignup.IsSelected` (participants =
+  `IsSelected && Role == Player`; waitlist = `!IsSelected && Role == Player`). The waitlist
+  markup is intact and correctly includes No voters for display.
+- The Quest Manage page (`Views/Quest/Manage.cshtml`) never had a waitlist table
+  (`git log -S "Waitlist"` on that file is empty); its finalized view only shows "Selected
+  Participants". So the "table removed on Manage" symptom is really No-voters contaminating
+  the Selected Participants list.
+
+The true root cause is the post-finalization waitlist auto-promotion added in Phase 44:
+
+- `QuestBoard.Domain/Enums/VoteType.cs` orders the enum `No = 0, Maybe = 1, Yes = 2`.
+- `PlayerSignupRepository.GetTopWaitlistedCandidateAsync` (lines ~80-93) ranks every
+  non-selected Player-role signup by vote priority (desc) then timestamp and returns the top
+  one — but it never filters out ineligible candidates. A signup with a No vote, or with no
+  vote for the finalized date, both resolve to priority `0` (No). When the whole waitlist is
+  No/non-voters, the "top candidate" is a No voter.
+- `QuestService.PromoteNextWaitlistedPlayerIfSeatFreedAsync` (lines ~317-344) then sets that
+  candidate's `IsSelected = true`. This runs whenever a seat frees — i.e. a selected player
+  votes No (`ChangeVoteAsync`) or revokes (`RevokeSignupAsync`).
+
+Result: a No voter is promoted into `IsSelected = true`, appears in the participant table with
+a red "No" badge on BOTH Details and Manage, and counts toward `TotalPlayerCount`. Because the
+demotion rule (`PlayerSignupRepository.ChangeVoteAsync`, lines ~67-72) already prevents a
+selected player from *keeping* a No vote, promotion is the only path that injects a No voter
+into the selected set — so a single, focused fix there resolves both pages at once.
+
+The seat-fill sibling path already encodes the correct rule ("A Yes or Maybe vote can both fill
+an open seat; only a No vote never grants a seat" — `QuestService.ChangeVoteAsync` lines
+~261-281). Promotion must be made consistent with it.
+</root_cause>
+
+<execution_context>
+@$HOME/.claude/gsd-core/workflows/execute-plan.md
+</execution_context>
+
+<context>
+@.planning/STATE.md
+@QuestBoard.Repository/PlayerSignupRepository.cs
+@QuestBoard.Domain/Services/QuestService.cs
+@QuestBoard.Domain/Extensions/WaitlistOrdering.cs
+@QuestBoard.Domain/Enums/VoteType.cs
+@QuestBoard.UnitTests/Repository/PlayerSignupRepositoryTests.cs
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Exclude No/non-voters from waitlist auto-promotion</name>
+  <files>QuestBoard.Repository/PlayerSignupRepository.cs</files>
+  <behavior>
+    - A waitlist of only No voters yields no promotion candidate (returns null) → seat stays open.
+    - A waitlisted Player with no DateVote for the finalized date is not a promotion candidate (returns null).
+    - A waitlist containing a No voter and a Maybe voter promotes the Maybe voter (No is skipped).
+    - Existing ordering is preserved among eligible (Yes/Maybe) candidates: Yes outranks Maybe; ties break by LastVoteChangeTime ?? SignupTime.
+  </behavior>
+  <action>
+    In `GetTopWaitlistedCandidateAsync`, after materializing `candidates` with `ToListAsync`, add
+    a `.Where(...)` clause to the in-memory LINQ chain (immediately before the existing
+    `.OrderByDescending(...)`) that keeps only signups whose vote for `finalizedProposedDateId` is
+    Yes or Maybe. Reuse the existing private helper `VoteForProposedDate(ps, finalizedProposedDateId)`
+    (which returns `int?`, null when the player has no vote for that date) and match it against
+    `(int)VoteType.Yes` and `(int)VoteType.Maybe` — a null or `(int)VoteType.No` result must be
+    excluded. Do NOT change the `OrderByDescending`/`ThenBy` ordering, the DB-side `.Where`
+    predicate, or the `WaitlistOrdering` extension (the display waitlist must still show No voters).
+
+    Add a plain-language comment (no phase/requirement IDs, per CLAUDE.md) explaining that only
+    players who confirmed availability (Yes or Maybe) for the finalized date may fill a freed
+    seat; a No vote — or no vote at all — never grants a seat, so those signups stay on the
+    waitlist and are never auto-promoted into the participant list. Keep the comment consistent
+    with the sibling seat-fill rule already documented in QuestService.ChangeVoteAsync.
+  </action>
+  <verify>
+    <automated>dotnet build QuestBoard.Repository/QuestBoard.Repository.csproj</automated>
+  </verify>
+  <done>
+    `GetTopWaitlistedCandidateAsync` filters promotion candidates to Yes/Maybe voters for the
+    finalized date; No voters and non-voters are excluded; project compiles.
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Add regression tests for promotion eligibility and run the suite</name>
+  <files>QuestBoard.UnitTests/Repository/PlayerSignupRepositoryTests.cs</files>
+  <action>
+    In the existing `GetTopWaitlistedCandidateAsync` test region (after
+    `GetTopWaitlistedCandidateAsync_NoWaitlistedPlayers_ReturnsNull`, ~line 349), add three
+    `[Fact]` tests following the established patterns in this file — use the existing
+    `CreateContext(nameof(...))`, `SeedQuestAndUserAsync(context, questId: 1, playerId: ...)`,
+    `MakeSignupEntity(id, questId: 1, isSelected: false)`, `CreateMapper()`, and
+    `TestContext.Current.CancellationToken` helpers, and attach votes via
+    `signup.DateVotes.Add(new PlayerDateVoteEntity { ProposedDateId = 5, PlayerSignupId = id, Vote = (int)VoteType.X })`
+    with `finalizedProposedDateId: 5`:
+
+    1. `GetTopWaitlistedCandidateAsync_AllNoVoters_ReturnsNull` — seed two non-selected Player
+       signups that both voted No for date 5; assert the returned candidate is null.
+    2. `GetTopWaitlistedCandidateAsync_NonVoterForFinalizedDate_ReturnsNull` — seed one
+       non-selected Player signup with NO DateVote for date 5 (empty DateVotes, or a vote for a
+       different ProposedDateId); assert null.
+    3. `GetTopWaitlistedCandidateAsync_SkipsNoVoter_PromotesMaybeVoter` — seed one No voter and
+       one Maybe voter (both non-selected Players) for date 5; assert the Maybe voter's Id is
+       returned (the No voter is skipped).
+
+    Do not modify or delete the existing tests; the current
+    `GetTopWaitlistedCandidateAsync_OrdersByVotePriorityThenTimestamp` (No/Maybe/Yes → Yes) and
+    the two same-vote ordering tests must still pass unchanged.
+  </action>
+  <verify>
+    <automated>dotnet test QuestBoard.UnitTests/QuestBoard.UnitTests.csproj --filter "FullyQualifiedName~PlayerSignupRepositoryTests"</automated>
+  </verify>
+  <done>
+    Three new regression tests pass; the full PlayerSignupRepositoryTests class (including the
+    pre-existing ordering tests) is green.
+  </done>
+</task>
+
+</tasks>
+
+<security_note>
+No new trust boundaries, inputs, or third-party packages. The change is a stricter server-side
+eligibility filter on an existing internal query (it narrows, never widens, who can be promoted),
+so it carries no new STRIDE exposure. No threat register required for this quick fix.
+</security_note>
+
+<verification>
+- `dotnet build` succeeds for the solution.
+- `dotnet test QuestBoard.UnitTests` passes in full (no regressions in the existing
+  `GetTopWaitlistedCandidateAsync` ordering tests).
+- Manual sanity (optional, DM account): finalize a quest whose leftover waitlist is only No
+  voters, then have a selected player vote No to free a seat — confirm no No voter is pulled into
+  Selected Participants on either the Details or Manage page, and the No voters remain listed in
+  the Details waitlist table.
+</verification>
+
+<success_criteria>
+- Waitlist auto-promotion only ever selects a player who voted Yes or Maybe for the finalized date.
+- No voters and non-voters stay on the waitlist (still shown in the Details waitlist table) and
+  never appear in the Selected Participants list on Details or Manage, nor count against
+  TotalPlayerCount.
+- No view files changed; both desktop and mobile views render correct data purely from the fixed
+  IsSelected state. All existing tests remain green.
+</success_criteria>
+
+<notes>
+Existing data caveat: this fix prevents future mis-promotions. Any quest that ALREADY has a No
+voter wrongly selected (from a promotion that happened before this fix) will not self-heal — the
+DM can correct it by removing that participant on the Manage page, or by "Open Quest" then
+re-finalizing. No data migration is included because a blanket demotion pass is out of scope for
+this focused fix and risks side effects on legitimately selected players.
+</notes>
+
+<output>
+Create `.planning/quick/260714-b0w-waitlist-table-missing-on-quest-details-/260714-b0w-SUMMARY.md` when done.
+</output>

--- a/.planning/quick/260714-b0w-waitlist-table-missing-on-quest-details-/260714-b0w-SUMMARY.md
+++ b/.planning/quick/260714-b0w-waitlist-table-missing-on-quest-details-/260714-b0w-SUMMARY.md
@@ -1,0 +1,144 @@
+---
+phase: quick-260714-b0w
+plan: 01
+subsystem: quests
+tags: [ef-core, razor, linq, waitlist, voting]
+
+requires: []
+provides:
+  - Waitlist auto-promotion filtered to Yes/Maybe voters for the finalized date
+  - Regression tests covering promotion eligibility (all-No, non-voter, No-skipped-Maybe-promoted)
+  - Waitlist section on Quest Manage page (desktop + mobile) mirroring Quest Details
+affects: [quest-signup, quest-manage, quest-details]
+
+tech-stack:
+  added: []
+  patterns:
+    - "Promotion eligibility filter mirrors seat-fill rule (Yes/Maybe grant a seat, No/none never does)"
+
+key-files:
+  created: []
+  modified:
+    - QuestBoard.Repository/PlayerSignupRepository.cs
+    - QuestBoard.UnitTests/Repository/PlayerSignupRepositoryTests.cs
+    - QuestBoard.Service/Views/Quest/Manage.cshtml
+    - QuestBoard.Service/Views/Quest/Manage.Mobile.cshtml
+
+key-decisions:
+  - "Fixed promotion eligibility with a single .Where() filter in GetTopWaitlistedCandidateAsync rather than changing VoteType enum ordering or the display waitlist ordering, keeping the fix minimal and focused on the actual defect."
+  - "Added a Waitlist section to Quest Manage (not in original symptom report but requested by user) so DMs can see who voted No while managing a finalized quest, matching the existing Details page pattern."
+
+patterns-established:
+  - "Waitlist display markup is duplicated per-view (Details/Details.Mobile/Manage/Manage.Mobile) rather than extracted to a partial, consistent with existing codebase convention."
+
+requirements-completed: [quick-260714-b0w]
+
+coverage:
+  - id: D1
+    description: "Waitlist auto-promotion only selects a player who voted Yes or Maybe for the finalized date; No voters and non-voters are never promoted."
+    requirement: "quick-260714-b0w"
+    verification:
+      - kind: unit
+        ref: "QuestBoard.UnitTests/Repository/PlayerSignupRepositoryTests.cs#GetTopWaitlistedCandidateAsync_AllNoVoters_ReturnsNull"
+        status: pass
+      - kind: unit
+        ref: "QuestBoard.UnitTests/Repository/PlayerSignupRepositoryTests.cs#GetTopWaitlistedCandidateAsync_NonVoterForFinalizedDate_ReturnsNull"
+        status: pass
+      - kind: unit
+        ref: "QuestBoard.UnitTests/Repository/PlayerSignupRepositoryTests.cs#GetTopWaitlistedCandidateAsync_SkipsNoVoter_PromotesMaybeVoter"
+        status: pass
+    human_judgment: false
+  - id: D2
+    description: "Existing vote-priority ordering (Yes outranks Maybe, tiebreak by LastVoteChangeTime/SignupTime) is preserved unchanged for eligible candidates."
+    verification:
+      - kind: unit
+        ref: "QuestBoard.UnitTests/Repository/PlayerSignupRepositoryTests.cs#GetTopWaitlistedCandidateAsync_OrdersByVotePriorityThenTimestamp"
+        status: pass
+      - kind: unit
+        ref: "QuestBoard.UnitTests/Repository/PlayerSignupRepositoryTests.cs#GetTopWaitlistedCandidateAsync_SameVote_OrdersByLastVoteChangeTimeFallingBackToSignupTime"
+        status: pass
+    human_judgment: false
+  - id: D3
+    description: "Quest Manage page (desktop and mobile) shows a Waitlist section for finalized quests, listing non-selected Player signups with their vote (Yes/Maybe/No/No Vote)."
+    requirement: "quick-260714-b0w"
+    verification: []
+    human_judgment: true
+    rationale: "Razor view rendering of a new UI section requires visual/manual confirmation in a browser against real quest data; not covered by unit tests."
+
+duration: 4min
+completed: 2026-07-14
+status: complete
+---
+
+# Quick Task 260714-b0w: Waitlist No-Voter Promotion Bug Summary
+
+**Fixed a one-line eligibility gap in waitlist auto-promotion that let No/non-voters fill freed seats, and added a Waitlist section to the DM-facing Quest Manage page (desktop + mobile) mirroring the existing Quest Details pattern.**
+
+## Performance
+
+- **Duration:** ~4 min
+- **Started:** 2026-07-14T06:51:28Z
+- **Completed:** 2026-07-14T06:55:48Z
+- **Tasks:** 3
+- **Files modified:** 4
+
+## Accomplishments
+- `GetTopWaitlistedCandidateAsync` now filters promotion candidates to Yes/Maybe voters for the finalized date before ranking, so a No voter or non-voter can no longer be auto-promoted into a freed seat (mirrors the existing seat-fill rule in `QuestService.ChangeVoteAsync`).
+- Three new regression tests cover: an all-No waitlist returning null, a non-voter for the finalized date returning null, and a No voter being skipped in favor of a Maybe voter — all existing ordering tests remain green (308/308 total unit tests pass).
+- Quest Manage (desktop `Manage.cshtml` and mobile `Manage.Mobile.cshtml`) now render a Waitlist table/card-list for finalized quests, showing each non-selected Player's name, character, and vote badge (including red "No"), giving DMs the same visibility that already existed on Quest Details.
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Exclude No/non-voters from waitlist auto-promotion** - `050cd0b` (fix)
+2. **Task 2: Add regression tests for promotion eligibility and run the suite** - `87c23dc` (test)
+3. **Task 3: Add Waitlist section to Quest Manage page (desktop + mobile)** - `1cd476a` (feat)
+
+**Plan metadata:** committed separately by the orchestrator after this summary.
+
+## Files Created/Modified
+- `QuestBoard.Repository/PlayerSignupRepository.cs` - Added a `.Where()` clause to `GetTopWaitlistedCandidateAsync` excluding candidates whose vote for the finalized date is not Yes or Maybe, with a plain-language comment explaining the rule.
+- `QuestBoard.UnitTests/Repository/PlayerSignupRepositoryTests.cs` - Added `GetTopWaitlistedCandidateAsync_AllNoVoters_ReturnsNull`, `GetTopWaitlistedCandidateAsync_NonVoterForFinalizedDate_ReturnsNull`, `GetTopWaitlistedCandidateAsync_SkipsNoVoter_PromotesMaybeVoter`.
+- `QuestBoard.Service/Views/Quest/Manage.cshtml` - Added `@using QuestBoard.Domain.Extensions` and a Waitlist table (desktop) rendered after Selected Participants for finalized quests.
+- `QuestBoard.Service/Views/Quest/Manage.Mobile.cshtml` - Added `@using QuestBoard.Domain.Extensions` and an equivalent Waitlist card-list (mobile) matching the existing Selected Participants card style.
+
+## Decisions Made
+- Filtered candidates in-memory using the existing `VoteForProposedDate` helper rather than pushing the filter into the DB-side `.Where` predicate, to keep the change minimal and localized to the LINQ chain the plan specified.
+- Preserved per-view markup duplication (no shared partial) for the new Waitlist section, consistent with how `Details.cshtml`/`Details.Mobile.cshtml`/`Manage.cshtml`/`Manage.Mobile.cshtml` already duplicate similar tables.
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 1 - Bug] Fixed Razor `@{ }` code-block syntax error in both Manage views**
+- **Found during:** Task 3 (Add Waitlist section to Quest Manage page)
+- **Issue:** The plan's markup blocks used `@{ ... }` to declare `waitlistFinalizedProposedDateManage`/`waitlistPlayersManage`, but that insertion point in both `Manage.cshtml` and `Manage.Mobile.cshtml` is already inside an enclosing C# code block (`@if (Model.IsFinalized) { ... }`), where Razor requires plain `{ }` for a nested statement block — using `@{` there raises `RZ1010: Unexpected "{" after "@" character`.
+- **Fix:** Removed the `@{`/`}` wrapper around the two variable declarations in both files, leaving them as plain C# statements inside the existing enclosing block (the subsequent `@if (waitlistPlayersManage.Any())` still needs its `@` since it's markup-transitioning).
+- **Files modified:** QuestBoard.Service/Views/Quest/Manage.cshtml, QuestBoard.Service/Views/Quest/Manage.Mobile.cshtml
+- **Verification:** `dotnet build QuestBoard.Service/QuestBoard.Service.csproj` succeeds with 0 errors after the fix (was previously RZ1010 x2).
+- **Committed in:** 1cd476a (Task 3 commit)
+
+---
+
+**Total deviations:** 1 auto-fixed (1 bug)
+**Impact on plan:** The fix was a pure Razor syntax correction with no change to the markup's visible output, ordering logic, or filter behavior specified in the plan. No scope creep.
+
+## Issues Encountered
+None beyond the Razor syntax deviation documented above.
+
+## User Setup Required
+None - no external service configuration required.
+
+## Next Phase Readiness
+- The waitlist promotion fix and new Manage waitlist view are both self-contained; no follow-up work is required.
+- Per the plan's `<notes>`, any quest that already has a wrongly-promoted No voter (from before this fix) will not self-heal automatically — the DM can correct it manually via Remove Participant or Open Quest + re-finalize. No data migration was included, as intended.
+- Manual sanity checks (finalize a quest with an all-No waitlist, free a seat, confirm no promotion; open Manage on a finalized quest with a waitlist to confirm the new section renders) are recommended before considering this fully verified in a live environment, per the plan's `<verification>` section.
+
+---
+*Phase: quick-260714-b0w*
+*Completed: 2026-07-14*
+
+## Self-Check: PASSED
+
+All 4 modified source files and this SUMMARY.md exist on disk; all 3 task commits (050cd0b, 87c23dc, 1cd476a) verified present in `git log --oneline --all`.

--- a/QuestBoard.Repository/PlayerSignupRepository.cs
+++ b/QuestBoard.Repository/PlayerSignupRepository.cs
@@ -84,7 +84,16 @@ internal class PlayerSignupRepository(QuestBoardContext dbContext, IMapper mappe
             .Where(ps => ps.QuestId == questId && !ps.IsSelected && ps.SignupRole == (int)SignupRole.Player)
             .ToListAsync(cancellationToken);
 
+        // A freed seat can only go to a player who confirmed availability (Yes or Maybe) for the
+        // finalized date; a No vote - or no vote at all - never grants a seat, so those signups
+        // stay on the waitlist and are never auto-promoted into the participant list. This
+        // mirrors the seat-fill rule already applied when a player casts a Yes/Maybe vote.
         var entity = candidates
+            .Where(ps =>
+            {
+                var vote = VoteForProposedDate(ps, finalizedProposedDateId);
+                return vote == (int)VoteType.Yes || vote == (int)VoteType.Maybe;
+            })
             .OrderByDescending(ps => WaitlistOrdering.VotePriority(VoteForProposedDate(ps, finalizedProposedDateId)))
             .ThenBy(ps => ps.LastVoteChangeTime ?? ps.SignupTime)
             .FirstOrDefault();

--- a/QuestBoard.Service/Views/Quest/Manage.Mobile.cshtml
+++ b/QuestBoard.Service/Views/Quest/Manage.Mobile.cshtml
@@ -1,4 +1,5 @@
 @using QuestBoard.Domain.Enums
+@using QuestBoard.Domain.Extensions
 @using QuestBoard.Domain.Interfaces
 @using QuestBoard.Domain.Models.QuestBoard
 @using QuestBoard.Service.Extensions
@@ -149,6 +150,44 @@ else
                 else
                 {
                     <p class="text-muted">No participants selected for this quest.</p>
+                }
+
+                var waitlistFinalizedProposedDateManage = Model.ProposedDates?.FirstOrDefault(pd => pd.Date == Model.FinalizedDate);
+                var waitlistPlayersManage = waitlistFinalizedProposedDateManage != null
+                    ? Model.PlayerSignups.Where(ps => !ps.IsSelected && ps.Role == SignupRole.Player).OrderWaitlist(waitlistFinalizedProposedDateManage.Id).ToList()
+                    : Model.PlayerSignups.Where(ps => !ps.IsSelected && ps.Role == SignupRole.Player).OrderBy(ps => ps.SignupTime).ToList();
+
+                @if (waitlistPlayersManage.Any())
+                {
+                    <h6 class="dm-manage-subheading mb-2">Waitlist</h6>
+                    @foreach (var player in waitlistPlayersManage)
+                    {
+                        var waitlistPlayerVoteManage = player.DateVotes
+                            ?.FirstOrDefault(dv => dv.ProposedDateId == waitlistFinalizedProposedDateManage?.Id)?.Vote;
+                        <div class="participant-row d-flex justify-content-between align-items-center py-2 border-bottom">
+                            <div>
+                                <span class="fw-bold dm-manage-player-name">@player.Player.Name</span>
+                                <br>
+                                <small>@(player.Character?.Name ?? "No character")</small>
+                            </div>
+                            @if (waitlistPlayerVoteManage == VoteType.Yes)
+                            {
+                                <span class="badge bg-success"><i class="fas fa-check me-1"></i>Yes</span>
+                            }
+                            else if (waitlistPlayerVoteManage == VoteType.Maybe)
+                            {
+                                <span class="badge bg-warning text-dark"><i class="fas fa-question me-1"></i>Maybe</span>
+                            }
+                            else if (waitlistPlayerVoteManage == VoteType.No)
+                            {
+                                <span class="badge bg-danger"><i class="fas fa-times me-1"></i>No</span>
+                            }
+                            else
+                            {
+                                <span class="badge bg-secondary"><i class="fas fa-minus me-1"></i>No Vote</span>
+                            }
+                        </div>
+                    }
                 }
 
                 <hr>

--- a/QuestBoard.Service/Views/Quest/Manage.cshtml
+++ b/QuestBoard.Service/Views/Quest/Manage.cshtml
@@ -1,4 +1,5 @@
 @using QuestBoard.Domain.Enums
+@using QuestBoard.Domain.Extensions
 @using QuestBoard.Domain.Interfaces
 @using QuestBoard.Domain.Models.QuestBoard
 @using QuestBoard.Service.Extensions
@@ -529,6 +530,89 @@ else
                             else
                             {
                                 <p class="text-muted">No participants selected for this quest.</p>
+                            }
+
+                            var waitlistFinalizedProposedDateManage = Model.ProposedDates?.FirstOrDefault(pd => pd.Date == Model.FinalizedDate);
+                            var waitlistPlayersManage = waitlistFinalizedProposedDateManage != null
+                                ? Model.PlayerSignups.Where(ps => !ps.IsSelected && ps.Role == SignupRole.Player).OrderWaitlist(waitlistFinalizedProposedDateManage.Id).ToList()
+                                : Model.PlayerSignups.Where(ps => !ps.IsSelected && ps.Role == SignupRole.Player).OrderBy(ps => ps.SignupTime).ToList();
+
+                            @if (waitlistPlayersManage.Any())
+                            {
+                                <h6>Waitlist:</h6>
+                                <div class="table-responsive">
+                                    <table class="table table-striped table-hover">
+                                        <thead>
+                                            <tr>
+                                                <th>Player Name</th>
+                                                <th>Character</th>
+                                                <th>Role</th>
+                                                <th>Vote</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            @foreach (var player in waitlistPlayersManage)
+                                            {
+                                                var waitlistPlayerVoteManage = player.DateVotes
+                                                    ?.FirstOrDefault(dv => dv.ProposedDateId == waitlistFinalizedProposedDateManage?.Id)?.Vote;
+                                                <tr>
+                                                    <td>@player.Player.Name</td>
+                                                    <td>
+                                                        @if (player.Character != null)
+                                                        {
+                                                            <div class="d-flex align-items-center">
+                                                                <img src="@Url.Action("GetCroppedPicture", "Characters", new { id = player.Character.Id })"
+                                                                     alt="@player.Character.Name"
+                                                                     class="character-mini-avatar me-2"
+                                                                     style="width: 32px; height: 32px; border-radius: 50%; object-fit: cover;"
+                                                                     onerror="this.style.display='none'; this.nextElementSibling.style.display='inline-flex';" />
+                                                                <span class="character-mini-avatar-placeholder me-2" style="width: 32px; height: 32px; display: none; align-items: center; justify-content: center; background-color: #6c757d; color: white; border-radius: 50%;">
+                                                                    <i class="fas fa-user"></i>
+                                                                </span>
+                                                                <span>@player.Character.Name</span>
+                                                            </div>
+                                                        }
+                                                        else
+                                                        {
+                                                            <span class="text-muted fst-italic">No character</span>
+                                                        }
+                                                    </td>
+                                                    <td>
+                                                        <span class="badge bg-secondary">
+                                                            <i class="fas fa-user me-1"></i>Player (Waitlist)
+                                                        </span>
+                                                    </td>
+                                                    <td>
+                                                        @if (waitlistPlayerVoteManage == VoteType.Yes)
+                                                        {
+                                                            <span class="badge bg-success">
+                                                                <i class="fas fa-check me-1"></i>Yes
+                                                            </span>
+                                                        }
+                                                        else if (waitlistPlayerVoteManage == VoteType.Maybe)
+                                                        {
+                                                            <span class="badge bg-warning text-dark">
+                                                                <i class="fas fa-question me-1"></i>Maybe
+                                                            </span>
+                                                        }
+                                                        else if (waitlistPlayerVoteManage == VoteType.No)
+                                                        {
+                                                            <span class="badge bg-danger">
+                                                                <i class="fas fa-times me-1"></i>No
+                                                            </span>
+                                                        }
+                                                        else
+                                                        {
+                                                            <span class="badge bg-secondary">
+                                                                <i class="fas fa-minus me-1"></i>No Vote
+                                                            </span>
+                                                        }
+                                                    </td>
+                                                </tr>
+                                            }
+                                        </tbody>
+                                    </table>
+                                </div>
                             }
 
                             <hr>

--- a/QuestBoard.UnitTests/Repository/PlayerSignupRepositoryTests.cs
+++ b/QuestBoard.UnitTests/Repository/PlayerSignupRepositoryTests.cs
@@ -348,6 +348,79 @@ public class PlayerSignupRepositoryTests
         candidate.Should().BeNull();
     }
 
+    [Fact]
+    public async Task GetTopWaitlistedCandidateAsync_AllNoVoters_ReturnsNull()
+    {
+        // Arrange: two waitlisted Player signups both voted No for the finalized date
+        await using var context = CreateContext(nameof(GetTopWaitlistedCandidateAsync_AllNoVoters_ReturnsNull));
+        await SeedQuestAndUserAsync(context, questId: 1, playerId: 101);
+        await SeedQuestAndUserAsync(context, questId: 1, playerId: 102);
+
+        var noVoter1 = MakeSignupEntity(1, questId: 1, isSelected: false);
+        noVoter1.DateVotes.Add(new PlayerDateVoteEntity { ProposedDateId = 5, PlayerSignupId = 1, Vote = (int)VoteType.No });
+
+        var noVoter2 = MakeSignupEntity(2, questId: 1, isSelected: false);
+        noVoter2.DateVotes.Add(new PlayerDateVoteEntity { ProposedDateId = 5, PlayerSignupId = 2, Vote = (int)VoteType.No });
+
+        context.PlayerSignups.AddRange(noVoter1, noVoter2);
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var repository = new PlayerSignupRepository(context, CreateMapper());
+
+        // Act
+        var candidate = await repository.GetTopWaitlistedCandidateAsync(1, finalizedProposedDateId: 5, TestContext.Current.CancellationToken);
+
+        // Assert: a No voter never grants a seat, so the whole-No waitlist yields no candidate
+        candidate.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetTopWaitlistedCandidateAsync_NonVoterForFinalizedDate_ReturnsNull()
+    {
+        // Arrange: a waitlisted Player signup with no vote at all for the finalized date
+        await using var context = CreateContext(nameof(GetTopWaitlistedCandidateAsync_NonVoterForFinalizedDate_ReturnsNull));
+        await SeedQuestAndUserAsync(context, questId: 1, playerId: 101);
+
+        var nonVoter = MakeSignupEntity(1, questId: 1, isSelected: false);
+        context.PlayerSignups.Add(nonVoter);
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var repository = new PlayerSignupRepository(context, CreateMapper());
+
+        // Act
+        var candidate = await repository.GetTopWaitlistedCandidateAsync(1, finalizedProposedDateId: 5, TestContext.Current.CancellationToken);
+
+        // Assert: no vote for the finalized date is treated the same as No — never a candidate
+        candidate.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetTopWaitlistedCandidateAsync_SkipsNoVoter_PromotesMaybeVoter()
+    {
+        // Arrange: one No voter and one Maybe voter waitlisted for the finalized date
+        await using var context = CreateContext(nameof(GetTopWaitlistedCandidateAsync_SkipsNoVoter_PromotesMaybeVoter));
+        await SeedQuestAndUserAsync(context, questId: 1, playerId: 101);
+        await SeedQuestAndUserAsync(context, questId: 1, playerId: 102);
+
+        var noVoter = MakeSignupEntity(1, questId: 1, isSelected: false);
+        noVoter.DateVotes.Add(new PlayerDateVoteEntity { ProposedDateId = 5, PlayerSignupId = 1, Vote = (int)VoteType.No });
+
+        var maybeVoter = MakeSignupEntity(2, questId: 1, isSelected: false);
+        maybeVoter.DateVotes.Add(new PlayerDateVoteEntity { ProposedDateId = 5, PlayerSignupId = 2, Vote = (int)VoteType.Maybe });
+
+        context.PlayerSignups.AddRange(noVoter, maybeVoter);
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var repository = new PlayerSignupRepository(context, CreateMapper());
+
+        // Act
+        var candidate = await repository.GetTopWaitlistedCandidateAsync(1, finalizedProposedDateId: 5, TestContext.Current.CancellationToken);
+
+        // Assert: the No voter is excluded, so the Maybe voter is promoted
+        candidate.Should().NotBeNull();
+        candidate!.Id.Should().Be(2);
+    }
+
     // -------------------------------------------------------------------
     // GetByIdWithQuestAsync (cross-group regression coverage — RemovePlayerSignup's lookup)
     // -------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fixes a regression where players who voted "No" (or never voted) for a finalized quest's date could get auto-promoted into the "Selected Participants" list when a seat freed up, counting against the quest's player capacity instead of staying on the waitlist. The bug was in `PlayerSignupRepository.GetTopWaitlistedCandidateAsync`, which ranked waitlisted players by vote priority but never excluded ineligible (No/non-voting) candidates.
- Adds a **Waitlist section to the Quest Manage page** (desktop + mobile), mirroring the existing Quest Details pattern, so DMs can see who is waitlisted — including who voted No — while managing a finalized quest.

## Why

The symptom reported: the waitlist appeared to be "missing" and No votes seemed to be counting against selected players. Investigation traced this to the post-finalization auto-promotion logic added in an earlier phase — it never filtered promotion candidates by vote type, so when the entire remaining waitlist was No/non-voters, the "top candidate" was still a No voter and got promoted.

## Changes

- `QuestBoard.Repository/PlayerSignupRepository.cs` — `GetTopWaitlistedCandidateAsync` now only considers Yes/Maybe voters for the finalized date as promotion candidates.
- `QuestBoard.UnitTests/Repository/PlayerSignupRepositoryTests.cs` — 3 new regression tests (all-No waitlist → null, non-voter → null, No skipped in favor of Maybe).
- `QuestBoard.Service/Views/Quest/Manage.cshtml` / `Manage.Mobile.cshtml` — new Waitlist table/card-list for finalized quests, reusing the existing `Model.PlayerSignups` data (no controller/repository/ViewModel changes needed).

## Caveat

This prevents *future* mis-promotions but does not retroactively fix quests that already have a wrongly-promoted No voter selected — a DM can correct those manually (remove the participant, or re-finalize).

## Test plan

- [x] `dotnet build` succeeds for the solution
- [x] `dotnet test QuestBoard.UnitTests` — 308/308 passing, including 3 new regression tests
- [ ] Manual check: finalize a quest with an all-No waitlist, free a seat, confirm no promotion
- [ ] Manual check: open Manage on a finalized quest with a waitlist — confirm the new Waitlist section renders correctly on desktop and mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)